### PR TITLE
Defaulter: emit no-op files

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -323,7 +323,6 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		if len(newDefaulters) == 0 {
 			glog.V(5).Infof("no defaulters in package %s", pkg.Name)
-			continue
 		}
 
 		packages = append(packages,


### PR DESCRIPTION
The tag said to process a directory.  If we don't emit the result file, the
kubernetes Make sysyetm will detect that this file is missing and repeatedly
try to generate it on every build.

Once this goes in, I will re-vendor it into the kube repo.

@wojtek-t 
