### PR TITLE
Protobuf: allow dashes in package names

### DIFF
--- a/examples/go-to-protobuf/protobuf/cmd.go
+++ b/examples/go-to-protobuf/protobuf/cmd.go
@@ -137,9 +137,6 @@ func Run(g *Generator) {
 			d = d[1:]
 			outputPackage = false
 		}
-		if strings.Contains(d, "-") {
-			log.Fatalf("Package names must be valid protobuf package identifiers, which allow only [a-z0-9_]: %s", d)
-		}
 		name := protoSafePackage(d)
 		parts := strings.SplitN(d, "=", 2)
 		if len(parts) > 1 {

--- a/examples/go-to-protobuf/protobuf/namer.go
+++ b/examples/go-to-protobuf/protobuf/namer.go
@@ -94,7 +94,8 @@ func (n *protobufNamer) GoNameToProtoName(name types.Name) types.Name {
 }
 
 func protoSafePackage(name string) string {
-	return strings.Replace(name, "/", ".", -1)
+	pkg := strings.Replace(name, "/", ".", -1)
+	return strings.Replace(pkg, "-", "_", -1)
 }
 
 type typeNameSet map[types.Name]*protobufPackage

--- a/examples/go-to-protobuf/protobuf/namer_test.go
+++ b/examples/go-to-protobuf/protobuf/namer_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import "testing"
+
+func TestProtoSafePackage(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		expected string
+	}{
+		{
+			pkg:      "foo",
+			expected: "foo",
+		},
+		{
+			pkg:      "foo/bar",
+			expected: "foo.bar",
+		},
+		{
+			pkg:      "foo/bar/baz",
+			expected: "foo.bar.baz",
+		},
+		{
+			pkg:      "foo/bar-baz/x/y-z/q",
+			expected: "foo.bar_baz.x.y_z.q",
+		},
+	}
+
+	for _, test := range tests {
+		actual := protoSafePackage(test.pkg)
+		if e, a := test.expected, actual; e != a {
+			t.Errorf("%s: expected %s, got %s", test.pkg, e, a)
+		}
+	}
+}


### PR DESCRIPTION
Convert - to _ for protobuf package names to allow protobuf code generation
support for go packages that have - in their names.

xref https://github.com/kubernetes/kubernetes/pull/33412

cc @smarterclayton 