### PR TITLE
Export unregistered deep copy functions, use custom DeepCopy impls

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -546,7 +546,14 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 	if len(t.Members) == 0 {
 		// at least do something with in/out to avoid "declared and not used" errors
 		sw.Do("_ = in\n_ = out\n", nil)
+		return
 	}
+
+	if hasDeepCopyMethod(t) {
+		sw.Do("*out = in.DeepCopy()\n", nil)
+		return
+	}
+
 	for _, m := range t.Members {
 		t := m.Type
 		if t.Kind == types.Alias {
@@ -587,11 +594,17 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 		default:
 			sw.Do("if in.$.name$ == nil {\n", args)
 			sw.Do("out.$.name$ = nil\n", args)
-			sw.Do("} else if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
-			sw.Do("return err\n", nil)
-			sw.Do("} else {\n", nil)
-			sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
-			sw.Do("}\n", nil)
+			if hasDeepCopyMethod(t) {
+				sw.Do("} else {\n", nil)
+				sw.Do("out.$.name$ = in.$.name$.DeepCopy()\n", args)
+				sw.Do("}\n", nil)
+			} else {
+				sw.Do("} else if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
+				sw.Do("return err\n", nil)
+				sw.Do("} else {\n", nil)
+				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
+				sw.Do("}\n", nil)
+			}
 		}
 	}
 }

--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -368,10 +368,18 @@ func (g *genDeepCopy) Init(c *generator.Context, w io.Writer) error {
 	cloner := c.Universe.Type(types.Name{Package: conversionPackagePath, Name: "Cloner"})
 	g.imports.AddType(cloner)
 	if !g.registerTypes {
-		// TODO: We should come up with a solution to register all generated
-		// deep-copy functions. However, for now, to avoid import cycles
-		// we register only those explicitly requested.
-		return nil
+		sw := generator.NewSnippetWriter(w, c, "$", "$")
+		sw.Do("// GetGeneratedDeepCopyFuncs returns the generated funcs, since we aren't registering them.\n", nil)
+		sw.Do("func GetGeneratedDeepCopyFuncs() []conversion.GeneratedDeepCopyFunc{\n", nil)
+		sw.Do("return []conversion.GeneratedDeepCopyFunc{\n", nil)
+		for _, t := range g.typesForInit {
+			args := argsFromType(t).
+				With("typeof", c.Universe.Package("reflect").Function("TypeOf"))
+			sw.Do("{Fn: $.type|dcFnName$, InType: $.typeof|raw$(&$.type|raw${})},\n", args)
+		}
+		sw.Do("}\n", nil)
+		sw.Do("}\n\n", nil)
+		return sw.Error()
 	}
 	glog.V(5).Infof("registering types in pkg %q", g.targetPackage)
 


### PR DESCRIPTION
Makes use of custom DeepCopy functions if defined (so we can define DeepCopy for types with unexported fields, and not switch to shallow copy in the middle of deep copy)

Adds function that returns generated deepcopy functions if they are not registered (see use at https://github.com/kubernetes/kubernetes/pull/35728/commits/cd69db639ae098e96b371c7aa774679dc90a3acb, sample generated diff at https://github.com/kubernetes/kubernetes/pull/35728/commits/bfb3a7eb007476283870d7fd1f2e2b0d2df71927)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/gengo/18)
<!-- Reviewable:end -->
