### PR TITLE
make import-boss attempt to look in the vendor folder

### DIFF
--- a/examples/import-boss/generators/import_restrict.go
+++ b/examples/import-boss/generators/import_restrict.go
@@ -192,8 +192,16 @@ func (importRuleFile) VerifyFile(f *generator.File, path string) error {
 	}
 
 	if rules == nil {
-		// No restrictions on this directory.
-		return nil
+		// No restrictions on this directory, double check under vendor.  Make an assumption about running in kube
+		vendorPath := strings.Replace(path, "/go/src/k8s.io/", "/go/src/k8s.io/kubernetes/vendor/k8s.io/", -1)
+		rules, actualPath, err = recursiveRead(vendorPath)
+		if err != nil {
+			return fmt.Errorf("error finding rules file: %v", err)
+		}
+
+		if rules == nil {
+			return nil
+		}
 	}
 
 	for _, r := range rules.Rules {


### PR DESCRIPTION
As we split out the genericapiserver, we need to enforce import requirements.  `staging/k8s.io/genericapiserver` is used as a vendored folder when building kube, so the `.import_restrictions` file exists in the vendor folder.

I know some effort went into removing kube references from this code, so I'm looking for recommendations to make this code generic.  I'm not very familiar with this repo.

I stumbled into this problem while working on https://github.com/kubernetes/kubernetes/pull/39384 .  I can commit that pull and continue for a while without `import-boss`, but I'd really like to have it.