### PR TITLE
handle vendoring for canonicalization

### DIFF
--- a/parser/local_parse_test.go
+++ b/parser/local_parse_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+import (
+	"testing"
+)
+
+func TestImportBuildPackage(t *testing.T) {
+	b := New()
+	if _, err := b.importBuildPackage("fake/dep"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := b.buildPackages["fake/dep"]; !ok {
+		t.Errorf("missing expected, but got %v", b.buildPackages)
+	}
+
+	if len(b.buildPackages) > 1 {
+		// this would happen if the canonicalization failed to normalize the path
+		// you'd get a k8s.io/gengo/vendor/fake/dep key too
+		t.Errorf("missing one, but got %v", b.buildPackages)
+	}
+}
+
+func TestCanonicalizeImportPath(t *testing.T) {
+	tcs := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:   "passthrough",
+			input:  "github.com/foo/bar",
+			output: "github.com/foo/bar",
+		},
+		{
+			name:   "simple",
+			input:  "github.com/foo/vendor/k8s.io/kubernetes/pkg/api",
+			output: "k8s.io/kubernetes/pkg/api",
+		},
+		{
+			name:   "deeper",
+			input:  "github.com/foo/bar/vendor/k8s.io/kubernetes/pkg/api",
+			output: "k8s.io/kubernetes/pkg/api",
+		},
+	}
+
+	for _, tc := range tcs {
+		actual := canonicalizeImportPath(tc.input)
+		if string(actual) != tc.output {
+			t.Errorf("%v: expected %q got %q", tc.name, tc.output, actual)
+		}
+	}
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -136,14 +136,15 @@ func (b *Builder) importBuildPackage(dir string) (*build.Package, error) {
 	// Remember it under the user-provided name.
 	glog.V(5).Infof("saving buildPackage %s", dir)
 	b.buildPackages[dir] = buildPkg
-	if dir != buildPkg.ImportPath {
+	canonicalPackage := canonicalizeImportPath(buildPkg.ImportPath)
+	if dir != string(canonicalPackage) {
 		// Since `dir` is not the canonical name, see if we knew it under another name.
-		if buildPkg, ok := b.buildPackages[buildPkg.ImportPath]; ok {
+		if buildPkg, ok := b.buildPackages[string(canonicalPackage)]; ok {
 			return buildPkg, nil
 		}
 		// Must be new, save it under the canonical name, too.
-		glog.V(5).Infof("saving buildPackage %s", buildPkg.ImportPath)
-		b.buildPackages[buildPkg.ImportPath] = buildPkg
+		glog.V(5).Infof("saving buildPackage %s", canonicalPackage)
+		b.buildPackages[string(canonicalPackage)] = buildPkg
 	}
 
 	return buildPkg, nil
@@ -223,7 +224,7 @@ func (b *Builder) AddDirRecursive(dir string) error {
 			rel := strings.TrimPrefix(path, prefix)
 			if rel != "" {
 				// Make a pkg path.
-				pkg := filepath.Join(b.buildPackages[dir].ImportPath, rel)
+				pkg := filepath.Join(string(canonicalizeImportPath(b.buildPackages[dir].ImportPath)), rel)
 
 				// Add it.
 				if _, err := b.importPackage(pkg, true); err != nil {
@@ -250,7 +251,7 @@ func (b *Builder) AddDirTo(dir string, u *types.Universe) error {
 	if _, err := b.importPackage(dir, true); err != nil {
 		return err
 	}
-	return b.findTypesIn(importPathString(b.buildPackages[dir].ImportPath), u)
+	return b.findTypesIn(canonicalizeImportPath(b.buildPackages[dir].ImportPath), u)
 }
 
 // The implementation of AddDir. A flag indicates whether this directory was
@@ -261,8 +262,9 @@ func (b *Builder) addDir(dir string, userRequested bool) error {
 	if err != nil {
 		return err
 	}
-	pkgPath := importPathString(buildPkg.ImportPath)
-	if dir != buildPkg.ImportPath {
+	canonicalPackage := canonicalizeImportPath(buildPkg.ImportPath)
+	pkgPath := canonicalPackage
+	if dir != string(canonicalPackage) {
 		glog.V(5).Infof("addDir %s, canonical path is %s", dir, pkgPath)
 	}
 
@@ -300,8 +302,9 @@ func (b *Builder) importPackage(dir string, userRequested bool) (*tc.Package, er
 
 	// Get the canonical path if we can.
 	if buildPkg := b.buildPackages[dir]; buildPkg != nil {
-		glog.V(5).Infof("importPackage %s, canonical path is %s", dir, buildPkg.ImportPath)
-		pkgPath = importPathString(buildPkg.ImportPath)
+		canonicalPackage := canonicalizeImportPath(buildPkg.ImportPath)
+		glog.V(5).Infof("importPackage %s, canonical path is %s", dir, canonicalPackage)
+		pkgPath = canonicalPackage
 	}
 
 	// If we have not seen this before, process it now.
@@ -318,8 +321,9 @@ func (b *Builder) importPackage(dir string, userRequested bool) (*tc.Package, er
 
 		// Get the canonical path now that it has been added.
 		if buildPkg := b.buildPackages[dir]; buildPkg != nil {
-			glog.V(5).Infof("importPackage %s, canonical path is %s", dir, buildPkg.ImportPath)
-			pkgPath = importPathString(buildPkg.ImportPath)
+			canonicalPackage := canonicalizeImportPath(buildPkg.ImportPath)
+			glog.V(5).Infof("importPackage %s, canonical path is %s", dir, canonicalPackage)
+			pkgPath = canonicalPackage
 		}
 	}
 
@@ -748,4 +752,14 @@ func (b *Builder) addVariable(u types.Universe, useName *types.Name, in *tc.Var)
 	out.Kind = types.DeclarationOf
 	out.Underlying = b.walkType(u, nil, in.Type())
 	return out
+}
+
+// canonicalizeImportPath takes an import path and returns the actual package.
+// It doesn't support nested vendoring.
+func canonicalizeImportPath(importPath string) importPathString {
+	if !strings.Contains(importPath, "/vendor/") {
+		return importPathString(importPath)
+	}
+
+	return importPathString(importPath[strings.Index(importPath, "/vendor/")+len("/vendor/"):])
 }

--- a/vendor/fake/dep/doc.go
+++ b/vendor/fake/dep/doc.go
@@ -1,0 +1,3 @@
+// this exists as a fake vendored dependency so that the vendor path canonicalization
+// can be reliably tested
+package dep


### PR DESCRIPTION
The `.ImportPath` from `build` produces a file reference, not the canonical package import path.  This results in package imports like this: `pkgfoo "k8s.io/kubernetes/vendor/k8s.io/fake-dep/pkgfoo"`.

I attempted to handle this by rewriting the import just prior to serialization, but that doesn't handle cases where the package is used to inspect functions.  Because it doesn't rewrite the package path when its discovered, the package is wrong for any comparison against that package. In particular, this check here in conversion fails https://github.com/kubernetes/kubernetes/blob/master/cmd/libs/go2idl/conversion-gen/generators/conversion.go#L144, because it compares `k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/conversion.Scope` against `k8s.io/apimachinery/pkg/conversion.Scope`.

This patch will mis-identify a package that is actually called `vendor`, but it does correctly handle nesting at any level.  It does
 1.  `k8s.io/kubernetes/vendor/github.com/foo/bar` -> ` github.com/foo/bar`
 2. `k8s.io/contrib/some/vendor/github.com/foo/bar` -> ` github.com/foo/bar`
 3. `k8s.io/contrib/vendor/github.com/foo/bar` -> `github.com/foo/bar`

I think this is better than our current state today, we have no "vendor" package anywhere dep'ed in today and someone would have to be kind of crazy to make it.

@thockin @lavalamp 