### PR TITLE
Preserve the filesystem location of a type

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -447,6 +447,7 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 	// We're keeping this package.  This call will create the record.
 	u.Package(string(pkgPath)).Name = pkg.Name()
 	u.Package(string(pkgPath)).Path = pkg.Path()
+	u.Package(string(pkgPath)).SourcePath = b.absPaths[pkgPath]
 
 	for _, f := range b.parsed[pkgPath] {
 		if strings.HasSuffix(f.name, "/doc.go") {

--- a/types/types.go
+++ b/types/types.go
@@ -94,6 +94,9 @@ type Package struct {
 	// Canonical name of this package-- its path.
 	Path string
 
+	// The location this package was loaded from
+	SourcePath string
+
 	// Short name of this package; the name that appears in the
 	// 'package x' line.
 	Name string


### PR DESCRIPTION
When dealing with vendored directories, we occasionally need to look at
the file path location. Copy the absPath for the package into the
package info so we have it available later in the gengo pipeline.

@deads2k @sttts @ncdc needed for kubernetes/kubernetes#39764