### PR TITLE
Tolerate vendored directories being scanned

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -226,8 +226,11 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var peerPkgs []string
 		if customArgs, ok := arguments.CustomArgs.(*CustomArgs); ok {
-			if len(customArgs.ExtraPeerDirs) > 0 {
-				peerPkgs = append(peerPkgs, customArgs.ExtraPeerDirs...)
+			for _, pkg := range customArgs.ExtraPeerDirs {
+				if i := strings.Index(pkg, "/vendor/"); i != -1 {
+					pkg = pkg[i+len("/vendor/"):]
+				}
+				peerPkgs = append(peerPkgs, pkg)
 			}
 		}
 		// Make sure our peer-packages are added and fully parsed.

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -171,6 +171,12 @@ func (b *Builder) AddFileForTest(pkg string, path string, src []byte) error {
 // flag indicates whether this file was user-requested or just from following
 // the import graph.
 func (b *Builder) addFile(pkgPath importPathString, path string, src []byte, userRequested bool) error {
+	for _, p := range b.parsed[pkgPath] {
+		if path == p.name {
+			glog.V(5).Infof("addFile %s %s already parsed, skipping", pkgPath, path)
+			return nil
+		}
+	}
 	glog.V(6).Infof("addFile %s %s", pkgPath, path)
 	p, err := parser.ParseFile(b.fset, path, src, parser.DeclarationErrors|parser.ParseComments)
 	if err != nil {


### PR DESCRIPTION
Some packages may appear multiple times while traversing a tree (a
package vendored by two separate sub vendors). Preserve the first to
prevent types from being redefined.

In defaulter-gen, handle paths that contain /vendor/ by treating them as
top level packages.

Extracted from kubernetes/kubernetes#39916