### PR TITLE
Fix lint failures in the deepcopy-gen

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -382,7 +382,7 @@ func (n *dcFnNamer) Name(t *types.Type) string {
 	if t.Name.Package == n.myPackage {
 		return "DeepCopy" + pubName
 	}
-	return fmt.Sprintf("%s.DeepCopy%s", n.tracker.LocalNameOf(t.Name.Package), pubName)
+	return fmt.Sprintf("%s.DeepCopy_%s", n.tracker.LocalNameOf(t.Name.Package), pubName)
 }
 
 func (g *genDeepCopy) Init(c *generator.Context, w io.Writer) error {
@@ -644,10 +644,10 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			} else {
 				// TODO: don't depend on kubernetes code for this
 				sw.Do("if in.$.name$ != nil {\n", args)
-				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err == nil {\n", args)
-				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
-				sw.Do("} else {\n", nil)
+				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
 				sw.Do("return err\n", nil)
+				sw.Do("} else {\n", nil)
+				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
 				sw.Do("}\n", nil)
 				sw.Do("}\n", nil)
 			}

--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -95,7 +95,7 @@ func extractTag(comments []string) *tagValue {
 func deepCopyNamer() *namer.NameStrategy {
 	return &namer.NameStrategy{
 		Join: func(pre string, in []string, post string) string {
-			return strings.Join(in, "_")
+			return strings.Join(in, "")
 		},
 		PrependPackageNames: 1,
 	}
@@ -380,7 +380,7 @@ func (n *dcFnNamer) Name(t *types.Type) string {
 	pubName := n.public.Name(t)
 	n.tracker.AddType(t)
 	if t.Name.Package == n.myPackage {
-		return "DeepCopy_" + pubName
+		return "DeepCopy" + pubName
 	}
 	return fmt.Sprintf("%s.DeepCopy_%s", n.tracker.LocalNameOf(t.Name.Package), pubName)
 }
@@ -459,6 +459,7 @@ func (g *genDeepCopy) GenerateType(c *generator.Context, t *types.Type, w io.Wri
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	args := argsFromType(t).
 		With("clonerType", types.Ref(conversionPackagePath, "Cloner"))
+	sw.Do("// $.type|dcFnName$ ...\n", args)
 	sw.Do("func $.type|dcFnName$(in interface{}, out interface{}, c *$.clonerType|raw$) error {{\n", args)
 	sw.Do("in := in.(*$.type|raw$)\nout := out.(*$.type|raw$)\n", argsFromType(t))
 	g.generateFor(t, sw)
@@ -522,10 +523,10 @@ func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
 				sw.Do("}\n", nil)
 				sw.Do("(*out)[key] = *newVal\n", nil)
 			} else {
-				sw.Do("if newVal, err := c.DeepCopy(&val); err != nil {\n", nil)
-				sw.Do("return err\n", nil)
-				sw.Do("} else {\n", nil)
+				sw.Do("if newVal, err := c.DeepCopy(&val); err == nil {\n", nil)
 				sw.Do("(*out)[key] = *newVal.(*$.|raw$)\n", t.Elem)
+				sw.Do("} else {\n", nil)
+				sw.Do("return err\n", nil)
 				sw.Do("}\n", nil)
 			}
 			sw.Do("}\n", nil)
@@ -563,10 +564,10 @@ func (g *genDeepCopy) doSlice(t *types.Type, sw *generator.SnippetWriter) {
 			sw.Do("return err\n", nil)
 			sw.Do("}\n", nil)
 		} else {
-			sw.Do("if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {\n", nil)
-			sw.Do("return err\n", nil)
-			sw.Do("} else {\n", nil)
+			sw.Do("if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {\n", nil)
 			sw.Do("(*out)[i] = *newVal.(*$.|raw$)\n", t.Elem)
+			sw.Do("} else {\n", nil)
+			sw.Do("return err\n", nil)
 			sw.Do("}\n", nil)
 		}
 		sw.Do("}\n", nil)
@@ -627,10 +628,10 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			} else {
 				// Fall back on the slow-path and hope it works.
 				// TODO: don't depend on kubernetes code for this
-				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
-				sw.Do("return err\n", nil)
-				sw.Do("} else {\n", nil)
+				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err == nil {\n", args)
 				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
+				sw.Do("} else {\n", nil)
+				sw.Do("return err\n", nil)
 				sw.Do("}\n", nil)
 			}
 		default:
@@ -672,10 +673,10 @@ func (g *genDeepCopy) doPointer(t *types.Type, sw *generator.SnippetWriter) {
 		sw.Do("return err\n", nil)
 		sw.Do("}\n", nil)
 	} else {
-		sw.Do("if newVal, err := c.DeepCopy(*in); err != nil {\n", nil)
-		sw.Do("return err\n", nil)
-		sw.Do("} else {\n", nil)
+		sw.Do("if newVal, err := c.DeepCopy(*in); err == nil {\n", nil)
 		sw.Do("*out = newVal.(*$.|raw$)\n", t.Elem)
+		sw.Do("} else {\n", nil)
+		sw.Do("return err\n", nil)
 		sw.Do("}\n", nil)
 	}
 }

--- a/examples/deepcopy-gen/test/wholepkg/a.go
+++ b/examples/deepcopy-gen/test/wholepkg/a.go
@@ -17,24 +17,24 @@ limitations under the License.
 package wholepkg
 
 // Trivial
-type Struct_Empty struct{}
+type StructEmpty struct{}
 
 // Only primitives
-type Struct_Primitives struct {
+type StructPrimitives struct {
 	BoolField   bool
 	IntField    int
 	StringField string
 	FloatField  float64
 }
-type Struct_Primitives_Alias Struct_Primitives
-type Struct_Embed_Struct_Primitives struct {
-	Struct_Primitives
+type StructPrimitivesAlias StructPrimitives
+type StructEmbedStructPrimitives struct {
+	StructPrimitives
 }
-type Struct_Embed_Int struct {
+type StructEmbedInt struct {
 	int
 }
-type Struct_Struct_Primitives struct {
-	StructField Struct_Primitives
+type StructStructPrimitives struct {
+	StructField StructPrimitives
 }
 
 // Manual DeepCopy method
@@ -46,28 +46,28 @@ func (m ManualStruct) DeepCopy() ManualStruct {
 	return m
 }
 
-type ManualStruct_Alias ManualStruct
+type ManualStructAlias ManualStruct
 
-type Struct_Embed_ManualStruct struct {
+type StructEmbedManualStruct struct {
 	ManualStruct
 }
 
 // Only pointers to primitives
-type Struct_PrimitivePointers struct {
+type StructPrimitivePointers struct {
 	BoolPtrField   *bool
 	IntPtrField    *int
 	StringPtrField *string
 	FloatPtrField  *float64
 }
-type Struct_PrimitivePointers_Alias Struct_PrimitivePointers
-type Struct_Embed_Struct_PrimitivePointers struct {
-	Struct_PrimitivePointers
+type StructPrimitivePointersAlias StructPrimitivePointers
+type StructEmbedStructPrimitivePointers struct {
+	StructPrimitivePointers
 }
-type Struct_Embed_Pointer struct {
+type StructEmbedPointer struct {
 	*int
 }
-type Struct_Struct_PrimitivePointers struct {
-	StructField Struct_PrimitivePointers
+type StructStructPrimitivePointers struct {
+	StructField StructPrimitivePointers
 }
 
 // Manual DeepCopy method
@@ -80,51 +80,51 @@ func (m ManualSlice) DeepCopy() ManualSlice {
 }
 
 // Slices
-type Struct_Slices struct {
+type StructSlices struct {
 	SliceBoolField                         []bool
 	SliceByteField                         []byte
 	SliceIntField                          []int
 	SliceStringField                       []string
 	SliceFloatField                        []float64
-	SliceStructPrimitivesField             []Struct_Primitives
-	SliceStructPrimitivesAliasField        []Struct_Primitives_Alias
-	SliceStructPrimitivePointersField      []Struct_PrimitivePointers
-	SliceStructPrimitivePointersAliasField []Struct_PrimitivePointers_Alias
+	SliceStructPrimitivesField             []StructPrimitives
+	SliceStructPrimitivesAliasField        []StructPrimitivesAlias
+	SliceStructPrimitivePointersField      []StructPrimitivePointers
+	SliceStructPrimitivePointersAliasField []StructPrimitivePointersAlias
 	SliceSliceIntField                     [][]int
 	SliceManualStructField                 []ManualStruct
 	ManualSliceField                       ManualSlice
 }
-type Struct_Slices_Alias Struct_Slices
-type Struct_Embed_Struct_Slices struct {
-	Struct_Slices
+type StructSlicesAlias StructSlices
+type StructEmbedStructSlices struct {
+	StructSlices
 }
-type Struct_Struct_Slices struct {
-	StructField Struct_Slices
+type StructStructSlices struct {
+	StructField StructSlices
 }
 
 // Everything
-type Struct_Everything struct {
+type StructEverything struct {
 	BoolField                 bool
 	IntField                  int
 	StringField               string
 	FloatField                float64
-	StructField               Struct_Primitives
-	EmptyStructField          Struct_Empty
+	StructField               StructPrimitives
+	EmptyStructField          StructEmpty
 	ManualStructField         ManualStruct
-	ManualStructAliasField    ManualStruct_Alias
+	ManualStructAliasField    ManualStructAlias
 	BoolPtrField              *bool
 	IntPtrField               *int
 	StringPtrField            *string
 	FloatPtrField             *float64
-	PrimitivePointersField    Struct_PrimitivePointers
+	PrimitivePointersField    StructPrimitivePointers
 	ManualStructPtrField      *ManualStruct
-	ManualStructAliasPtrField *ManualStruct_Alias
+	ManualStructAliasPtrField *ManualStructAlias
 	SliceBoolField            []bool
 	SliceByteField            []byte
 	SliceIntField             []int
 	SliceStringField          []string
 	SliceFloatField           []float64
-	SlicesField               Struct_Slices
+	SlicesField               StructSlices
 	SliceManualStructField    []ManualStruct
 	ManualSliceField          ManualSlice
 }

--- a/examples/deepcopy-gen/test/wholepkg/b.go
+++ b/examples/deepcopy-gen/test/wholepkg/b.go
@@ -17,4 +17,4 @@ limitations under the License.
 package wholepkg
 
 // Another type in another file.
-type Struct_B struct{}
+type StructB struct{}

--- a/examples/deepcopy-gen/test/wholepkg/deepcopy_generated.go
+++ b/examples/deepcopy-gen/test/wholepkg/deepcopy_generated.go
@@ -28,30 +28,31 @@ import (
 // GetGeneratedDeepCopyFuncs returns the generated funcs, since we aren't registering them.
 func GetGeneratedDeepCopyFuncs() []conversion.GeneratedDeepCopyFunc {
 	return []conversion.GeneratedDeepCopyFunc{
-		{Fn: DeepCopy_wholepkg_ManualStruct, InType: reflect.TypeOf(&ManualStruct{})},
-		{Fn: DeepCopy_wholepkg_ManualStruct_Alias, InType: reflect.TypeOf(&ManualStruct_Alias{})},
-		{Fn: DeepCopy_wholepkg_Struct_B, InType: reflect.TypeOf(&Struct_B{})},
-		{Fn: DeepCopy_wholepkg_Struct_Embed_Int, InType: reflect.TypeOf(&Struct_Embed_Int{})},
-		{Fn: DeepCopy_wholepkg_Struct_Embed_ManualStruct, InType: reflect.TypeOf(&Struct_Embed_ManualStruct{})},
-		{Fn: DeepCopy_wholepkg_Struct_Embed_Pointer, InType: reflect.TypeOf(&Struct_Embed_Pointer{})},
-		{Fn: DeepCopy_wholepkg_Struct_Embed_Struct_PrimitivePointers, InType: reflect.TypeOf(&Struct_Embed_Struct_PrimitivePointers{})},
-		{Fn: DeepCopy_wholepkg_Struct_Embed_Struct_Primitives, InType: reflect.TypeOf(&Struct_Embed_Struct_Primitives{})},
-		{Fn: DeepCopy_wholepkg_Struct_Embed_Struct_Slices, InType: reflect.TypeOf(&Struct_Embed_Struct_Slices{})},
-		{Fn: DeepCopy_wholepkg_Struct_Empty, InType: reflect.TypeOf(&Struct_Empty{})},
-		{Fn: DeepCopy_wholepkg_Struct_Everything, InType: reflect.TypeOf(&Struct_Everything{})},
-		{Fn: DeepCopy_wholepkg_Struct_PrimitivePointers, InType: reflect.TypeOf(&Struct_PrimitivePointers{})},
-		{Fn: DeepCopy_wholepkg_Struct_PrimitivePointers_Alias, InType: reflect.TypeOf(&Struct_PrimitivePointers_Alias{})},
-		{Fn: DeepCopy_wholepkg_Struct_Primitives, InType: reflect.TypeOf(&Struct_Primitives{})},
-		{Fn: DeepCopy_wholepkg_Struct_Primitives_Alias, InType: reflect.TypeOf(&Struct_Primitives_Alias{})},
-		{Fn: DeepCopy_wholepkg_Struct_Slices, InType: reflect.TypeOf(&Struct_Slices{})},
-		{Fn: DeepCopy_wholepkg_Struct_Slices_Alias, InType: reflect.TypeOf(&Struct_Slices_Alias{})},
-		{Fn: DeepCopy_wholepkg_Struct_Struct_PrimitivePointers, InType: reflect.TypeOf(&Struct_Struct_PrimitivePointers{})},
-		{Fn: DeepCopy_wholepkg_Struct_Struct_Primitives, InType: reflect.TypeOf(&Struct_Struct_Primitives{})},
-		{Fn: DeepCopy_wholepkg_Struct_Struct_Slices, InType: reflect.TypeOf(&Struct_Struct_Slices{})},
+		{Fn: DeepCopywholepkgManualStruct, InType: reflect.TypeOf(&ManualStruct{})},
+		{Fn: DeepCopywholepkgManualStructAlias, InType: reflect.TypeOf(&ManualStructAlias{})},
+		{Fn: DeepCopywholepkgStructB, InType: reflect.TypeOf(&StructB{})},
+		{Fn: DeepCopywholepkgStructEmbedInt, InType: reflect.TypeOf(&StructEmbedInt{})},
+		{Fn: DeepCopywholepkgStructEmbedManualStruct, InType: reflect.TypeOf(&StructEmbedManualStruct{})},
+		{Fn: DeepCopywholepkgStructEmbedPointer, InType: reflect.TypeOf(&StructEmbedPointer{})},
+		{Fn: DeepCopywholepkgStructEmbedStructPrimitivePointers, InType: reflect.TypeOf(&StructEmbedStructPrimitivePointers{})},
+		{Fn: DeepCopywholepkgStructEmbedStructPrimitives, InType: reflect.TypeOf(&StructEmbedStructPrimitives{})},
+		{Fn: DeepCopywholepkgStructEmbedStructSlices, InType: reflect.TypeOf(&StructEmbedStructSlices{})},
+		{Fn: DeepCopywholepkgStructEmpty, InType: reflect.TypeOf(&StructEmpty{})},
+		{Fn: DeepCopywholepkgStructEverything, InType: reflect.TypeOf(&StructEverything{})},
+		{Fn: DeepCopywholepkgStructPrimitivePointers, InType: reflect.TypeOf(&StructPrimitivePointers{})},
+		{Fn: DeepCopywholepkgStructPrimitivePointersAlias, InType: reflect.TypeOf(&StructPrimitivePointersAlias{})},
+		{Fn: DeepCopywholepkgStructPrimitives, InType: reflect.TypeOf(&StructPrimitives{})},
+		{Fn: DeepCopywholepkgStructPrimitivesAlias, InType: reflect.TypeOf(&StructPrimitivesAlias{})},
+		{Fn: DeepCopywholepkgStructSlices, InType: reflect.TypeOf(&StructSlices{})},
+		{Fn: DeepCopywholepkgStructSlicesAlias, InType: reflect.TypeOf(&StructSlicesAlias{})},
+		{Fn: DeepCopywholepkgStructStructPrimitivePointers, InType: reflect.TypeOf(&StructStructPrimitivePointers{})},
+		{Fn: DeepCopywholepkgStructStructPrimitives, InType: reflect.TypeOf(&StructStructPrimitives{})},
+		{Fn: DeepCopywholepkgStructStructSlices, InType: reflect.TypeOf(&StructStructSlices{})},
 	}
 }
 
-func DeepCopy_wholepkg_ManualStruct(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgManualStruct ...
+func DeepCopywholepkgManualStruct(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ManualStruct)
 		out := out.(*ManualStruct)
@@ -60,47 +61,52 @@ func DeepCopy_wholepkg_ManualStruct(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_wholepkg_ManualStruct_Alias(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgManualStructAlias ...
+func DeepCopywholepkgManualStructAlias(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*ManualStruct_Alias)
-		out := out.(*ManualStruct_Alias)
+		in := in.(*ManualStructAlias)
+		out := out.(*ManualStructAlias)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_B(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructB ...
+func DeepCopywholepkgStructB(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_B)
-		out := out.(*Struct_B)
+		in := in.(*StructB)
+		out := out.(*StructB)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Embed_Int(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmbedInt ...
+func DeepCopywholepkgStructEmbedInt(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Embed_Int)
-		out := out.(*Struct_Embed_Int)
+		in := in.(*StructEmbedInt)
+		out := out.(*StructEmbedInt)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Embed_ManualStruct(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmbedManualStruct ...
+func DeepCopywholepkgStructEmbedManualStruct(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Embed_ManualStruct)
-		out := out.(*Struct_Embed_ManualStruct)
+		in := in.(*StructEmbedManualStruct)
+		out := out.(*StructEmbedManualStruct)
 		*out = *in
 		out.ManualStruct = in.ManualStruct.DeepCopy()
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Embed_Pointer(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmbedPointer ...
+func DeepCopywholepkgStructEmbedPointer(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Embed_Pointer)
-		out := out.(*Struct_Embed_Pointer)
+		in := in.(*StructEmbedPointer)
+		out := out.(*StructEmbedPointer)
 		*out = *in
 		if in.int != nil {
 			in, out := &in.int, &out.int
@@ -111,52 +117,57 @@ func DeepCopy_wholepkg_Struct_Embed_Pointer(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Embed_Struct_PrimitivePointers(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmbedStructPrimitivePointers ...
+func DeepCopywholepkgStructEmbedStructPrimitivePointers(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Embed_Struct_PrimitivePointers)
-		out := out.(*Struct_Embed_Struct_PrimitivePointers)
+		in := in.(*StructEmbedStructPrimitivePointers)
+		out := out.(*StructEmbedStructPrimitivePointers)
 		*out = *in
-		if err := DeepCopy_wholepkg_Struct_PrimitivePointers(&in.Struct_PrimitivePointers, &out.Struct_PrimitivePointers, c); err != nil {
+		if err := DeepCopywholepkgStructPrimitivePointers(&in.StructPrimitivePointers, &out.StructPrimitivePointers, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Embed_Struct_Primitives(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmbedStructPrimitives ...
+func DeepCopywholepkgStructEmbedStructPrimitives(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Embed_Struct_Primitives)
-		out := out.(*Struct_Embed_Struct_Primitives)
+		in := in.(*StructEmbedStructPrimitives)
+		out := out.(*StructEmbedStructPrimitives)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Embed_Struct_Slices(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmbedStructSlices ...
+func DeepCopywholepkgStructEmbedStructSlices(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Embed_Struct_Slices)
-		out := out.(*Struct_Embed_Struct_Slices)
+		in := in.(*StructEmbedStructSlices)
+		out := out.(*StructEmbedStructSlices)
 		*out = *in
-		if err := DeepCopy_wholepkg_Struct_Slices(&in.Struct_Slices, &out.Struct_Slices, c); err != nil {
+		if err := DeepCopywholepkgStructSlices(&in.StructSlices, &out.StructSlices, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Empty(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEmpty ...
+func DeepCopywholepkgStructEmpty(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Empty)
-		out := out.(*Struct_Empty)
+		in := in.(*StructEmpty)
+		out := out.(*StructEmpty)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Everything(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructEverything ...
+func DeepCopywholepkgStructEverything(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Everything)
-		out := out.(*Struct_Everything)
+		in := in.(*StructEverything)
+		out := out.(*StructEverything)
 		*out = *in
 		out.ManualStructField = in.ManualStructField.DeepCopy()
 		if in.BoolPtrField != nil {
@@ -179,7 +190,7 @@ func DeepCopy_wholepkg_Struct_Everything(in interface{}, out interface{}, c *con
 			*out = new(float64)
 			**out = **in
 		}
-		if err := DeepCopy_wholepkg_Struct_PrimitivePointers(&in.PrimitivePointersField, &out.PrimitivePointersField, c); err != nil {
+		if err := DeepCopywholepkgStructPrimitivePointers(&in.PrimitivePointersField, &out.PrimitivePointersField, c); err != nil {
 			return err
 		}
 		if in.ManualStructPtrField != nil {
@@ -189,7 +200,7 @@ func DeepCopy_wholepkg_Struct_Everything(in interface{}, out interface{}, c *con
 		}
 		if in.ManualStructAliasPtrField != nil {
 			in, out := &in.ManualStructAliasPtrField, &out.ManualStructAliasPtrField
-			*out = new(ManualStruct_Alias)
+			*out = new(ManualStructAlias)
 			**out = **in
 		}
 		if in.SliceBoolField != nil {
@@ -217,7 +228,7 @@ func DeepCopy_wholepkg_Struct_Everything(in interface{}, out interface{}, c *con
 			*out = make([]float64, len(*in))
 			copy(*out, *in)
 		}
-		if err := DeepCopy_wholepkg_Struct_Slices(&in.SlicesField, &out.SlicesField, c); err != nil {
+		if err := DeepCopywholepkgStructSlices(&in.SlicesField, &out.SlicesField, c); err != nil {
 			return err
 		}
 		if in.SliceManualStructField != nil {
@@ -234,10 +245,11 @@ func DeepCopy_wholepkg_Struct_Everything(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_wholepkg_Struct_PrimitivePointers(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructPrimitivePointers ...
+func DeepCopywholepkgStructPrimitivePointers(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_PrimitivePointers)
-		out := out.(*Struct_PrimitivePointers)
+		in := in.(*StructPrimitivePointers)
+		out := out.(*StructPrimitivePointers)
 		*out = *in
 		if in.BoolPtrField != nil {
 			in, out := &in.BoolPtrField, &out.BoolPtrField
@@ -263,10 +275,11 @@ func DeepCopy_wholepkg_Struct_PrimitivePointers(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_wholepkg_Struct_PrimitivePointers_Alias(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructPrimitivePointersAlias ...
+func DeepCopywholepkgStructPrimitivePointersAlias(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_PrimitivePointers_Alias)
-		out := out.(*Struct_PrimitivePointers_Alias)
+		in := in.(*StructPrimitivePointersAlias)
+		out := out.(*StructPrimitivePointersAlias)
 		*out = *in
 		if in.BoolPtrField != nil {
 			in, out := &in.BoolPtrField, &out.BoolPtrField
@@ -292,28 +305,31 @@ func DeepCopy_wholepkg_Struct_PrimitivePointers_Alias(in interface{}, out interf
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Primitives(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructPrimitives ...
+func DeepCopywholepkgStructPrimitives(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Primitives)
-		out := out.(*Struct_Primitives)
+		in := in.(*StructPrimitives)
+		out := out.(*StructPrimitives)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Primitives_Alias(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructPrimitivesAlias ...
+func DeepCopywholepkgStructPrimitivesAlias(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Primitives_Alias)
-		out := out.(*Struct_Primitives_Alias)
+		in := in.(*StructPrimitivesAlias)
+		out := out.(*StructPrimitivesAlias)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Slices(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructSlices ...
+func DeepCopywholepkgStructSlices(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Slices)
-		out := out.(*Struct_Slices)
+		in := in.(*StructSlices)
+		out := out.(*StructSlices)
 		*out = *in
 		if in.SliceBoolField != nil {
 			in, out := &in.SliceBoolField, &out.SliceBoolField
@@ -342,28 +358,28 @@ func DeepCopy_wholepkg_Struct_Slices(in interface{}, out interface{}, c *convers
 		}
 		if in.SliceStructPrimitivesField != nil {
 			in, out := &in.SliceStructPrimitivesField, &out.SliceStructPrimitivesField
-			*out = make([]Struct_Primitives, len(*in))
+			*out = make([]StructPrimitives, len(*in))
 			copy(*out, *in)
 		}
 		if in.SliceStructPrimitivesAliasField != nil {
 			in, out := &in.SliceStructPrimitivesAliasField, &out.SliceStructPrimitivesAliasField
-			*out = make([]Struct_Primitives_Alias, len(*in))
+			*out = make([]StructPrimitivesAlias, len(*in))
 			copy(*out, *in)
 		}
 		if in.SliceStructPrimitivePointersField != nil {
 			in, out := &in.SliceStructPrimitivePointersField, &out.SliceStructPrimitivePointersField
-			*out = make([]Struct_PrimitivePointers, len(*in))
+			*out = make([]StructPrimitivePointers, len(*in))
 			for i := range *in {
-				if err := DeepCopy_wholepkg_Struct_PrimitivePointers(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopywholepkgStructPrimitivePointers(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
 		}
 		if in.SliceStructPrimitivePointersAliasField != nil {
 			in, out := &in.SliceStructPrimitivePointersAliasField, &out.SliceStructPrimitivePointersAliasField
-			*out = make([]Struct_PrimitivePointers_Alias, len(*in))
+			*out = make([]StructPrimitivePointersAlias, len(*in))
 			for i := range *in {
-				if err := DeepCopy_wholepkg_Struct_PrimitivePointers_Alias(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopywholepkgStructPrimitivePointersAlias(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -393,10 +409,11 @@ func DeepCopy_wholepkg_Struct_Slices(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Slices_Alias(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructSlicesAlias ...
+func DeepCopywholepkgStructSlicesAlias(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Slices_Alias)
-		out := out.(*Struct_Slices_Alias)
+		in := in.(*StructSlicesAlias)
+		out := out.(*StructSlicesAlias)
 		*out = *in
 		if in.SliceBoolField != nil {
 			in, out := &in.SliceBoolField, &out.SliceBoolField
@@ -425,28 +442,28 @@ func DeepCopy_wholepkg_Struct_Slices_Alias(in interface{}, out interface{}, c *c
 		}
 		if in.SliceStructPrimitivesField != nil {
 			in, out := &in.SliceStructPrimitivesField, &out.SliceStructPrimitivesField
-			*out = make([]Struct_Primitives, len(*in))
+			*out = make([]StructPrimitives, len(*in))
 			copy(*out, *in)
 		}
 		if in.SliceStructPrimitivesAliasField != nil {
 			in, out := &in.SliceStructPrimitivesAliasField, &out.SliceStructPrimitivesAliasField
-			*out = make([]Struct_Primitives_Alias, len(*in))
+			*out = make([]StructPrimitivesAlias, len(*in))
 			copy(*out, *in)
 		}
 		if in.SliceStructPrimitivePointersField != nil {
 			in, out := &in.SliceStructPrimitivePointersField, &out.SliceStructPrimitivePointersField
-			*out = make([]Struct_PrimitivePointers, len(*in))
+			*out = make([]StructPrimitivePointers, len(*in))
 			for i := range *in {
-				if err := DeepCopy_wholepkg_Struct_PrimitivePointers(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopywholepkgStructPrimitivePointers(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
 		}
 		if in.SliceStructPrimitivePointersAliasField != nil {
 			in, out := &in.SliceStructPrimitivePointersAliasField, &out.SliceStructPrimitivePointersAliasField
-			*out = make([]Struct_PrimitivePointers_Alias, len(*in))
+			*out = make([]StructPrimitivePointersAlias, len(*in))
 			for i := range *in {
-				if err := DeepCopy_wholepkg_Struct_PrimitivePointers_Alias(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopywholepkgStructPrimitivePointersAlias(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -476,33 +493,36 @@ func DeepCopy_wholepkg_Struct_Slices_Alias(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Struct_PrimitivePointers(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructStructPrimitivePointers ...
+func DeepCopywholepkgStructStructPrimitivePointers(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Struct_PrimitivePointers)
-		out := out.(*Struct_Struct_PrimitivePointers)
+		in := in.(*StructStructPrimitivePointers)
+		out := out.(*StructStructPrimitivePointers)
 		*out = *in
-		if err := DeepCopy_wholepkg_Struct_PrimitivePointers(&in.StructField, &out.StructField, c); err != nil {
+		if err := DeepCopywholepkgStructPrimitivePointers(&in.StructField, &out.StructField, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Struct_Primitives(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructStructPrimitives ...
+func DeepCopywholepkgStructStructPrimitives(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Struct_Primitives)
-		out := out.(*Struct_Struct_Primitives)
+		in := in.(*StructStructPrimitives)
+		out := out.(*StructStructPrimitives)
 		*out = *in
 		return nil
 	}
 }
 
-func DeepCopy_wholepkg_Struct_Struct_Slices(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopywholepkgStructStructSlices ...
+func DeepCopywholepkgStructStructSlices(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
-		in := in.(*Struct_Struct_Slices)
-		out := out.(*Struct_Struct_Slices)
+		in := in.(*StructStructSlices)
+		out := out.(*StructStructSlices)
 		*out = *in
-		if err := DeepCopy_wholepkg_Struct_Slices(&in.StructField, &out.StructField, c); err != nil {
+		if err := DeepCopywholepkgStructSlices(&in.StructField, &out.StructField, c); err != nil {
 			return err
 		}
 		return nil

--- a/examples/deepcopy-gen/test/wholepkg/deepcopy_test.go
+++ b/examples/deepcopy-gen/test/wholepkg/deepcopy_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 func TestDeepCopy(t *testing.T) {
-	x := Struct_Primitives{}
-	y := Struct_Primitives{}
+	x := StructPrimitives{}
+	y := StructPrimitives{}
 
 	if !reflect.DeepEqual(&x, &y) {
 		t.Errorf("objects should be equal to start, but are not")
@@ -39,7 +39,7 @@ func TestDeepCopy(t *testing.T) {
 		t.Errorf("objects should not be equal, but are")
 	}
 
-	if err := DeepCopy_wholepkg_Struct_Primitives(&x, &y, nil); err != nil {
+	if err := DeepCopywholepkgStructPrimitives(&x, &y, nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if !reflect.DeepEqual(&x, &y) {


### PR DESCRIPTION
The changes in this patch takes care of lint failures resulted due to
deepcopy generated files. The total numbers of such lint failures are
around fifty errors. There are main three types of lint errors,
1. Generated functions name have underscore in them.
2. Generated functions are missing comment.
3. Some of the generated functions have unnecessary 'else' block for a given
   'if' loop.
For example, in the generated code, few of fifity some total failures are:
/zz_generated.deepcopy.go:60:6: don't use underscores in Go names;
/zz_generated.deepcopy.go:60:1: exported function should have comment or
be unexported
/zz_generated.deepcopy.go:116:10: if block ends with a return statement,
so drop this else and outdent its block