### PR TITLE
Fix lint failures in the defaulter generated files

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -55,7 +55,7 @@ func checkTag(comments []string, require ...string) bool {
 
 func defaultFnNamer() *namer.NameStrategy {
 	return &namer.NameStrategy{
-		Prefix: "SetDefaults_",
+		Prefix: "SetDefaults",
 		Join: func(pre string, in []string, post string) string {
 			return pre + strings.Join(in, "_") + post
 		},
@@ -64,7 +64,7 @@ func defaultFnNamer() *namer.NameStrategy {
 
 func objectDefaultFnNamer() *namer.NameStrategy {
 	return &namer.NameStrategy{
-		Prefix: "SetObjectDefaults_",
+		Prefix: "SetObjectDefaults",
 		Join: func(pre string, in []string, post string) string {
 			return pre + strings.Join(in, "_") + post
 		},
@@ -551,6 +551,7 @@ func defaultingArgsFromType(inType *types.Type) generator.Args {
 }
 
 func (g *genDefaulter) generateDefaulter(inType *types.Type, callTree *callNode, sw *generator.SnippetWriter) {
+	sw.Do("// $.inType|objectdefaultfn$ ... \n", defaultingArgsFromType(inType))
 	sw.Do("func $.inType|objectdefaultfn$(in *$.inType|raw$) {\n", defaultingArgsFromType(inType))
 	callTree.WriteMethod("in", 0, nil, sw)
 	sw.Do("}\n\n", nil)


### PR DESCRIPTION
The changes in this patch takes care of lint failures resulted due to
defaulter generated files. There are main two types of lint errors,
1. Generated functions name have underscore in them.
2. Generated functions are missing comment.

For example, in the generated code, some of the failures are:
zz_generated.defaults.go:53:6: don't use underscores in Go names…
zz_generated.defaults.go:38:1: exported function SetObjectDefaults_Binding
should have comment or be unexported..