### PR TITLE
Fix if loop related lint failures in the deepcopy-gen

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -523,11 +523,12 @@ func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
 				sw.Do("}\n", nil)
 				sw.Do("(*out)[key] = *newVal\n", nil)
 			} else {
-				sw.Do("if newVal, err := c.DeepCopy(&val); err != nil {\n", nil)
+				sw.Do("newVal, err := c.DeepCopy(&val)\n", nil)
+				sw.Do("if err != nil {\n", nil)
 				sw.Do("return err\n", nil)
-				sw.Do("} else {\n", nil)
-				sw.Do("(*out)[key] = *newVal.(*$.|raw$)\n", t.Elem)
 				sw.Do("}\n", nil)
+				sw.Do("(*out)[key] = *newVal.(*$.|raw$)\n", t.Elem)
+				sw.Do("\n", nil)
 			}
 			sw.Do("}\n", nil)
 		}
@@ -564,11 +565,12 @@ func (g *genDeepCopy) doSlice(t *types.Type, sw *generator.SnippetWriter) {
 			sw.Do("return err\n", nil)
 			sw.Do("}\n", nil)
 		} else {
-			sw.Do("if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {\n", nil)
+			sw.Do("newVal, err := c.DeepCopy(&(*in)[i])\n", nil)
+			sw.Do("if err != nil {\n", nil)
 			sw.Do("return err\n", nil)
-			sw.Do("} else {\n", nil)
-			sw.Do("(*out)[i] = *newVal.(*$.|raw$)\n", t.Elem)
 			sw.Do("}\n", nil)
+			sw.Do("(*out)[i] = *newVal.(*$.|raw$)\n", t.Elem)
+			sw.Do("\n", nil)
 		}
 		sw.Do("}\n", nil)
 	}
@@ -628,11 +630,12 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			} else {
 				// Fall back on the slow-path and hope it works.
 				// TODO: don't depend on kubernetes code for this
-				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
+				sw.Do("newVal, err := c.DeepCopy(&in.$.name$)\n", args)
+				sw.Do("if err != nil {\n", nil)
 				sw.Do("return err\n", nil)
-				sw.Do("} else {\n", nil)
-				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
 				sw.Do("}\n", nil)
+				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
+				sw.Do("\n", nil)
 			}
 		default:
 			// Interfaces, Arrays, and other Kinds we don't understand.
@@ -644,11 +647,12 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			} else {
 				// TODO: don't depend on kubernetes code for this
 				sw.Do("if in.$.name$ != nil {\n", args)
-				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
+				sw.Do("newVal, err := c.DeepCopy(&in.$.name$)\n", args)
+				sw.Do("if err != nil {\n", nil)
 				sw.Do("return err\n", nil)
-				sw.Do("} else {\n", nil)
-				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
 				sw.Do("}\n", nil)
+				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
+				sw.Do("\n", nil)
 				sw.Do("}\n", nil)
 			}
 		}
@@ -673,11 +677,12 @@ func (g *genDeepCopy) doPointer(t *types.Type, sw *generator.SnippetWriter) {
 		sw.Do("return err\n", nil)
 		sw.Do("}\n", nil)
 	} else {
-		sw.Do("if newVal, err := c.DeepCopy(*in); err != nil {\n", nil)
+		sw.Do("newVal, err := c.DeepCopy(*in)\n", nil)
+		sw.Do("if err != nil {\n", nil)
 		sw.Do("return err\n", nil)
-		sw.Do("} else {\n", nil)
-		sw.Do("*out = newVal.(*$.|raw$)\n", t.Elem)
 		sw.Do("}\n", nil)
+		sw.Do("*out = newVal.(*$.|raw$)\n", t.Elem)
+		sw.Do("\n", nil)
 	}
 }
 


### PR DESCRIPTION
The changes in this patch takes care of lint failures due to unreachable
else statements. For example one of the failures is,
/zz_generated.deepcopy.go:116:10: if block ends with a return statement,
so drop this else and outdent its block