### PR TITLE
remove init func from deepcopy.go

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -405,9 +405,6 @@ func (g *genDeepCopy) Init(c *generator.Context, w io.Writer) error {
 	glog.V(5).Infof("Registering types in pkg %q", g.targetPackage)
 
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
-	sw.Do("func init() {\n", nil)
-	sw.Do("SchemeBuilder.Register(RegisterDeepCopies)\n", nil)
-	sw.Do("}\n\n", nil)
 
 	scheme := c.Universe.Type(types.Name{Package: runtimePackagePath, Name: "Scheme"})
 	schemePtr := &types.Type{


### PR DESCRIPTION
Removing these lines: https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/zz_generated.deepcopy.go#L31-L33

They should be registered here:
https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/register.go#L37

@lavalamp can you take a look? Thanks.