### PR TITLE
Generate defaulters for aliased types correctly

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -422,6 +422,10 @@ func buildCallTreeForType(t *types.Type, root bool, existingDefaulters, newDefau
 				parent.children = append(parent.children, *child)
 			}
 		}
+	case types.Alias:
+		if child := buildCallTreeForType(t.Underlying, false, existingDefaulters, newDefaulters); child != nil {
+			parent.children = append(parent.children, *child)
+		}
 	}
 	if len(parent.children) == 0 && len(parent.call) == 0 {
 		//glog.V(6).Infof("decided type %s needs no generation", t.Name)


### PR DESCRIPTION
Needed by https://github.com/kubernetes/kubernetes/pull/45294 (that PR already includes this change, so you can see it "in action"... it's required in order to keep generating the recursive defaulting functions through aliased slice types)

Otherwise, aliased slice types don't detect registered defaulters on the element types