### PR TITLE
fix a bug in gengo that parses comments in doc.go multiple times

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -458,6 +458,9 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 	for _, f := range b.parsed[pkgPath] {
 		if strings.HasSuffix(f.name, "/doc.go") {
 			tp := u.Package(string(pkgPath))
+			// findTypesIn might be called multiple times. Clean up tp.Comments
+			// to avoid repeatedly fill same comments to it.
+			tp.Comments = []string{}
 			for i := range f.file.Comments {
 				tp.Comments = append(tp.Comments, splitLines(f.file.Comments[i].Text())...)
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -101,10 +101,11 @@ type Package struct {
 	// 'package x' line.
 	Name string
 
-	// DocComments from doc.go, if any.
+	// The comment right above the package declaration in doc.go, if any.
 	DocComments []string
 
-	// Comments from doc.go, if any.
+	// All comments from doc.go, if any.
+	// TODO: remove Comments and use DocComments everywhere.
 	Comments []string
 
 	// Types within this package, indexed by their name (*not* including


### PR DESCRIPTION
findTypesIn might be called multiple times and thus the content of doc.go might be recorded in the universe multiple time.

@lavalamp @thockin 