### PR TITLE
Revert "Fix if loop related lint failures in the deepcopy-gen"

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -523,12 +523,11 @@ func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
 				sw.Do("}\n", nil)
 				sw.Do("(*out)[key] = *newVal\n", nil)
 			} else {
-				sw.Do("newVal, err := c.DeepCopy(&val)\n", nil)
-				sw.Do("if err != nil {\n", nil)
+				sw.Do("if newVal, err := c.DeepCopy(&val); err != nil {\n", nil)
 				sw.Do("return err\n", nil)
-				sw.Do("}\n", nil)
+				sw.Do("} else {\n", nil)
 				sw.Do("(*out)[key] = *newVal.(*$.|raw$)\n", t.Elem)
-				sw.Do("\n", nil)
+				sw.Do("}\n", nil)
 			}
 			sw.Do("}\n", nil)
 		}
@@ -565,12 +564,11 @@ func (g *genDeepCopy) doSlice(t *types.Type, sw *generator.SnippetWriter) {
 			sw.Do("return err\n", nil)
 			sw.Do("}\n", nil)
 		} else {
-			sw.Do("newVal, err := c.DeepCopy(&(*in)[i])\n", nil)
-			sw.Do("if err != nil {\n", nil)
+			sw.Do("if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {\n", nil)
 			sw.Do("return err\n", nil)
-			sw.Do("}\n", nil)
+			sw.Do("} else {\n", nil)
 			sw.Do("(*out)[i] = *newVal.(*$.|raw$)\n", t.Elem)
-			sw.Do("\n", nil)
+			sw.Do("}\n", nil)
 		}
 		sw.Do("}\n", nil)
 	}
@@ -630,12 +628,11 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			} else {
 				// Fall back on the slow-path and hope it works.
 				// TODO: don't depend on kubernetes code for this
-				sw.Do("newVal, err := c.DeepCopy(&in.$.name$)\n", args)
-				sw.Do("if err != nil {\n", nil)
+				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
 				sw.Do("return err\n", nil)
-				sw.Do("}\n", nil)
+				sw.Do("} else {\n", nil)
 				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
-				sw.Do("\n", nil)
+				sw.Do("}\n", nil)
 			}
 		default:
 			// Interfaces, Arrays, and other Kinds we don't understand.
@@ -647,12 +644,11 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 			} else {
 				// TODO: don't depend on kubernetes code for this
 				sw.Do("if in.$.name$ != nil {\n", args)
-				sw.Do("newVal, err := c.DeepCopy(&in.$.name$)\n", args)
-				sw.Do("if err != nil {\n", nil)
+				sw.Do("if newVal, err := c.DeepCopy(&in.$.name$); err != nil {\n", args)
 				sw.Do("return err\n", nil)
-				sw.Do("}\n", nil)
+				sw.Do("} else {\n", nil)
 				sw.Do("out.$.name$ = *newVal.(*$.type|raw$)\n", args)
-				sw.Do("\n", nil)
+				sw.Do("}\n", nil)
 				sw.Do("}\n", nil)
 			}
 		}
@@ -677,12 +673,11 @@ func (g *genDeepCopy) doPointer(t *types.Type, sw *generator.SnippetWriter) {
 		sw.Do("return err\n", nil)
 		sw.Do("}\n", nil)
 	} else {
-		sw.Do("newVal, err := c.DeepCopy(*in)\n", nil)
-		sw.Do("if err != nil {\n", nil)
+		sw.Do("if newVal, err := c.DeepCopy(*in); err != nil {\n", nil)
 		sw.Do("return err\n", nil)
-		sw.Do("}\n", nil)
+		sw.Do("} else {\n", nil)
 		sw.Do("*out = newVal.(*$.|raw$)\n", t.Elem)
-		sw.Do("\n", nil)
+		sw.Do("}\n", nil)
 	}
 }
 


### PR DESCRIPTION
This reverts commit a438c28332fb46fff47d61b9d115275885c5c818 since it produces code that won't compile (see https://github.com/kubernetes/gengo/pull/46/files#r116396781) so master is usable (we need to bump as a prereq of kubernetes/kubernetes#45294)... can revisit this if we decide we want to jump through scoping or variable name hoops to avoid this lint error (I personally don't think it's worth it)