### PR TITLE
fix default-gen's output path for packages in vendor directory

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -328,10 +328,15 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			glog.V(5).Infof("no defaulters in package %s", pkg.Name)
 		}
 
+		fqPkgPath := pkg.Path
+		if strings.Contains(pkg.SourcePath, "/vendor/") {
+			fqPkgPath = filepath.Join("k8s.io", "kubernetes", "vendor", pkg.Path)
+		}
+
 		packages = append(packages,
 			&generator.DefaultPackage{
 				PackageName: filepath.Base(pkg.Path),
-				PackagePath: pkg.Path,
+				PackagePath: fqPkgPath,
 				HeaderText:  header,
 				GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
 					return []generator.Generator{


### PR DESCRIPTION
Default-gen doesn't generate any code if the types are defined in vendor/. This PR fixes that. The code is copied from convernsion-gen: https://github.com/kubernetes/kubernetes/blob/v1.7.0-alpha.4/cmd/libs/go2idl/conversion-gen/generators/conversion.go#L240-L243.

I encountered bug in https://github.com/kubernetes/kubernetes/pull/46294.