### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - lavalamp
   - wojtek-t

--- a/examples/defaulter-gen/OWNERS
+++ b/examples/defaulter-gen/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - smarterclayton

--- a/examples/go-to-protobuf/OWNERS
+++ b/examples/go-to-protobuf/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - smarterclayton


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: https://github.com/kubernetes/test-infra/issues/3851