### PR TITLE
Format files using goimports

### DIFF
--- a/generator/execute.go
+++ b/generator/execute.go
@@ -19,13 +19,13 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"go/format"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/tools/imports"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 
@@ -131,7 +131,6 @@ func assembleGolangFile(w io.Writer, f *File) {
 
 	if len(f.Imports) > 0 {
 		fmt.Fprint(w, "import (\n")
-		// TODO: sort imports like goimports does.
 		for i := range f.Imports {
 			if strings.Contains(i, "\"") {
 				// they included quotes, or are using the
@@ -159,9 +158,13 @@ func assembleGolangFile(w io.Writer, f *File) {
 	w.Write(f.Body.Bytes())
 }
 
+func importsWrapper(src []byte) ([]byte, error) {
+	return imports.Process("", src, nil)
+}
+
 func NewGolangFile() *DefaultFileType {
 	return &DefaultFileType{
-		Format:   format.Source,
+		Format:   importsWrapper,
 		Assemble: assembleGolangFile,
 	}
 }


### PR DESCRIPTION
Format files using x/tools/imports to get the import sort order from goimports.

This is to address https://github.com/kubernetes/kubernetes/issues/55542