### PR TITLE
Use proper trim function to remove prefix of function names

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -578,7 +578,7 @@ func splitLines(str string) []string {
 }
 
 func tcFuncNameToName(in string) types.Name {
-	name := strings.TrimLeft(in, "func ")
+	name := strings.TrimPrefix(in, "func ")
 	nameParts := strings.Split(name, "(")
 	return tcNameToName(nameParts[0])
 }


### PR DESCRIPTION
When extracting function names from their signature we want to cut the `func ` part from the beginning.
The current code uses `strings.TrimLeft` which removes all leading Unicode code points contained in `[f,u,n,c, ]` [1].

This behaviour returns invalid function names, e.g. when the package starts with `f`, `u`, `n` or `c`.

What we actually want is just removing the `func ` prefix, done by `strings.TrimPrefix` [2].

[1] https://golang.org/pkg/strings/#TrimLeft
[2] https://golang.org/pkg/strings/#TrimPrefix