### PR TITLE
Fix default-gen for []* type

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -470,6 +470,9 @@ func (c *callTreeForType) build(t *types.Type, root bool) *callNode {
 	case types.Slice, types.Array:
 		if child := c.build(t.Elem, false); child != nil {
 			child.index = true
+			if t.Elem.Kind == types.Pointer {
+				child.elem = true
+			}
 			parent.children = append(parent.children, *child)
 		}
 	case types.Map:
@@ -756,7 +759,12 @@ func (n *callNode) WriteMethod(varName string, depth int, ancestors []*callNode,
 	switch {
 	case n.index:
 		sw.Do("for $.index$ := range $.var$ {\n", vars)
-		sw.Do("$.local$ := &$.var$[$.index$]\n", vars)
+		if n.elem {
+			sw.Do("$.local$ := $.var$[$.index$]\n", vars)
+		} else {
+			sw.Do("$.local$ := &$.var$[$.index$]\n", vars)
+		}
+
 		n.writeCalls(local, true, sw)
 		for i := range n.children {
 			n.children[i].WriteMethod(local, depth+1, append(ancestors, n), sw)


### PR DESCRIPTION
Now type slice are almost all non-pointer, like **Items []Pod**. 
But this([Items []*PartialObjectMetadata](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1alpha1/types.go#L160)) slice's elem/kind is ptr
And default-gen will hard-code add **&** before Item like a := **&in**.Spec.Template.Spec.Volumes[i] .
when Item's kind is ptr, it shouldn't add &. Otherwise it will generate **.

In my env, I add a private element in [ObjectMeta](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1alpha1/types.go#L151), and add manual default. So the generate_default will involve it and failed when compile.
![image](https://user-images.githubusercontent.com/28776356/34404710-234c3fc8-ebea-11e7-9d48-d7619c41311c.png)
