### PR TITLE
Improve pluralisation

### DIFF
--- a/namer/plural_namer_test.go
+++ b/namer/plural_namer_test.go
@@ -55,6 +55,56 @@ func TestPluralNamer(t *testing.T) {
 			"buses",
 			"Buses",
 		},
+		{
+			"Fizz",
+			"fizzes",
+			"Fizzes",
+		},
+		{
+			"Search",
+			"searches",
+			"Searches",
+		},
+		{
+			"Autograph",
+			"autographs",
+			"Autographs",
+		},
+		{
+			"Dispatch",
+			"dispatches",
+			"Dispatches",
+		},
+		{
+			"Earth",
+			"earths",
+			"Earths",
+		},
+		{
+			"City",
+			"cities",
+			"Cities",
+		},
+		{
+			"Ray",
+			"rays",
+			"Rays",
+		},
+		{
+			"Fountain",
+			"fountains",
+			"Fountains",
+		},
+		{
+			"Life",
+			"lives",
+			"Lives",
+		},
+		{
+			"Leaf",
+			"leaves",
+			"Leaves",
+		},
 	}
 	for _, c := range cases {
 		testType := &types.Type{Name: types.Name{Name: c.typeName}}


### PR DESCRIPTION
Improve some of the more trivial cases of pluralisation. I bumped in to this when using CRD autogenerates and it got "elasticsearch" wrong :)

The original implementation was pretty naive and this isn't massively better as theres so many gotchas in english language, but I tried to cover the easy cases.