### PR TITLE
Remove outdated set-gen test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ jobs:
         - go test -v ./...
     - stage: Verify examples
       script: 
-        - go run ./examples/set-gen/main.go -i k8s.io/gengo/examples/set-gen/sets/types -o ./examples/set-gen/sets --verify-only 
         - go run ./examples/import-boss/main.go -i k8s.io/gengo/... --verify-only


### PR DESCRIPTION
Since set-gen now has a Makefile, it is tested as part of the ```Run tests``` stage, there is no reason to test it this way as well.

This test does not run set-gen in the usual way of calling go build and then checking the git diff.