### PR TITLE
Fix compatibility of gengo with Windows

### DIFF
--- a/examples/import-boss/generators/import_restrict_test.go
+++ b/examples/import-boss/generators/import_restrict_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generators
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -24,12 +25,14 @@ func TestRemoveLastDir(t *testing.T) {
 	table := map[string]struct{ newPath, removedDir string }{
 		"a/b/c": {"a/c", "b"},
 	}
-	for input, expect := range table {
+	for slashInput, expect := range table {
+		input := filepath.FromSlash(slashInput)
+
 		gotPath, gotRemoved := removeLastDir(input)
-		if e, a := expect.newPath, gotPath; e != a {
+		if e, a := filepath.FromSlash(expect.newPath), gotPath; e != a {
 			t.Errorf("%v: wanted %v, got %v", input, e, a)
 		}
-		if e, a := expect.removedDir, gotRemoved; e != a {
+		if e, a := filepath.FromSlash(expect.removedDir), gotRemoved; e != a {
 			t.Errorf("%v: wanted %v, got %v", input, e, a)
 		}
 	}

--- a/generator/import_tracker.go
+++ b/generator/import_tracker.go
@@ -17,8 +17,9 @@ limitations under the License.
 package generator
 
 import (
-	"path/filepath"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
@@ -37,7 +38,14 @@ func NewImportTracker(typesToAdd ...*types.Type) namer.ImportTracker {
 
 func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 	path := t.Package
-	dirs := strings.Split(path, string(filepath.Separator))
+
+	// Using backslashes in package names causes gengo to produce Go code which
+	// will not compile with the gc compiler. See the comment on GoSeperator.
+	if strings.ContainsRune(path, '\\') {
+		glog.Warningf("Warning: backslash used in import path '%v', this is unsupported.\n", path)
+	}
+
+	dirs := strings.Split(path, namer.GoSeperator)
 	for n := len(dirs) - 1; n >= 0; n-- {
 		// TODO: bikeshed about whether it's more readable to have an
 		// _, something else, or nothing between directory names.

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -23,6 +23,17 @@ import (
 	"k8s.io/gengo/types"
 )
 
+const (
+	// GoSeperator is used to split go import paths.
+	// Forward slash is used instead of filepath.Seperator because it is the
+	// only universally-accepted path delimiter and the only delimiter not
+	// potentially forbidden by Go compilers. (In particular gc does not allow
+	// the use of backslashes in import paths.)
+	// See https://golang.org/ref/spec#Import_declarations.
+	// See also https://github.com/kubernetes/gengo/issues/83#issuecomment-367040772.
+	GoSeperator = "/"
+)
+
 // Returns whether a name is a private Go name.
 func IsPrivateGoName(name string) bool {
 	return len(name) == 0 || strings.ToLower(name[:1]) == name[:1]
@@ -187,7 +198,7 @@ var (
 
 // filters out unwanted directory names and sanitizes remaining names.
 func (ns *NameStrategy) filterDirs(path string) []string {
-	allDirs := strings.Split(path, string(filepath.Separator))
+	allDirs := strings.Split(path, GoSeperator)
 	dirs := make([]string, 0, len(allDirs))
 	for _, p := range allDirs {
 		if ns.IgnoreWords == nil || !ns.IgnoreWords[p] {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -226,12 +227,12 @@ func (b *Builder) AddDirRecursive(dir string) error {
 	// filepath.Walk includes the root dir, but we already did that, so we'll
 	// remove that prefix and rebuild a package import path.
 	prefix := b.buildPackages[dir].Dir
-	fn := func(path string, info os.FileInfo, err error) error {
+	fn := func(filePath string, info os.FileInfo, err error) error {
 		if info != nil && info.IsDir() {
-			rel := strings.TrimPrefix(path, prefix)
+			rel := filepath.ToSlash(strings.TrimPrefix(filePath, prefix))
 			if rel != "" {
 				// Make a pkg path.
-				pkg := filepath.Join(string(canonicalizeImportPath(b.buildPackages[dir].ImportPath)), rel)
+				pkg := path.Join(string(canonicalizeImportPath(b.buildPackages[dir].ImportPath)), rel)
 
 				// Add it.
 				if _, err := b.importPackage(pkg, true); err != nil {
@@ -488,7 +489,7 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 	u.Package(string(pkgPath)).SourcePath = b.absPaths[pkgPath]
 
 	for _, f := range b.parsed[pkgPath] {
-		if strings.HasSuffix(f.name, "/doc.go") {
+		if _, fileName := filepath.Split(f.name); fileName == "doc.go" {
 			tp := u.Package(string(pkgPath))
 			// findTypesIn might be called multiple times. Clean up tp.Comments
 			// to avoid repeatedly fill same comments to it.

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -18,6 +18,7 @@ package parser_test
 
 import (
 	"bytes"
+	"path"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -61,7 +62,7 @@ type file struct {
 func construct(t *testing.T, files []file, testNamer namer.Namer) (*parser.Builder, types.Universe, []*types.Type) {
 	b := parser.New()
 	for _, f := range files {
-		if err := b.AddFileForTest(filepath.Dir(f.path), f.path, []byte(f.contents)); err != nil {
+		if err := b.AddFileForTest(path.Dir(f.path), filepath.FromSlash(f.path), []byte(f.contents)); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Swaps some usages of path and filepath and replaces some usages of PathSeperator with "/" in order to make consistent usage of slash-paths and filepaths in gengo. Also fixes up a couple of unit tests which fail on Windows otherwise.