### PR TITLE
Passing a path of "" is undefined for different operating systems. 

### DIFF
--- a/generator/execute.go
+++ b/generator/execute.go
@@ -159,7 +159,11 @@ func assembleGolangFile(w io.Writer, f *File) {
 }
 
 func importsWrapper(src []byte) ([]byte, error) {
-	return imports.Process("", src, nil)
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return imports.Process(dir, src, nil)
 }
 
 func NewGolangFile() *DefaultFileType {


### PR DESCRIPTION
Passing a path of "" is undefined for different operating systems. To make the behavior consistent with Linux pass in the current working directory.

This does not work on Windows due to: https://github.com/golang/go/issues/24441