### PR TITLE
Follow pkg alias convention of kube of not having _ between dirs

### DIFF
--- a/generator/import_tracker.go
+++ b/generator/import_tracker.go
@@ -47,13 +47,12 @@ func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 
 	dirs := strings.Split(path, namer.GoSeperator)
 	for n := len(dirs) - 1; n >= 0; n-- {
-		// TODO: bikeshed about whether it's more readable to have an
-		// _, something else, or nothing between directory names.
-		name := strings.Join(dirs[n:], "_")
+		// follow kube convention of not having anything between directory names
+		name := strings.Join(dirs[n:], "")
 		// These characters commonly appear in import paths for go
 		// packages, but aren't legal go names. So we'll sanitize.
-		name = strings.Replace(name, ".", "_", -1)
-		name = strings.Replace(name, "-", "_", -1)
+		name = strings.Replace(name, ".", "", -1)
+		name = strings.Replace(name, "-", "", -1)
 		if _, found := tracker.PathOf(name); found {
 			// This name collides with some other package
 			continue


### PR DESCRIPTION
We are starting excluding certain generated files from linting and verify scripts because we use underscores in import aliases. Instead, we should fix Gengo here to comply with the kube conventions.

Compare https://github.com/kubernetes/kubernetes/pull/64664/files#diff-4175e534855bc6fa66d08dee56797817R29