### PR TITLE
Sanitize pkg names containing _ with underscore-less alias

### DIFF
--- a/generator/import_tracker.go
+++ b/generator/import_tracker.go
@@ -49,6 +49,7 @@ func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 	for n := len(dirs) - 1; n >= 0; n-- {
 		// follow kube convention of not having anything between directory names
 		name := strings.Join(dirs[n:], "")
+		name = strings.Replace(name, "_", "", -1)
 		// These characters commonly appear in import paths for go
 		// packages, but aren't legal go names. So we'll sanitize.
 		name = strings.Replace(name, ".", "", -1)


### PR DESCRIPTION
Package names like pkg/apis/custom_metrics were still aliased with custom_metrics. After this PR the alias is custommetrics.