### PR TITLE
import-boss: add inverse import rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ jobs:
         - go test -v ./...
     - stage: Verify examples
       script:
-        - go run ./examples/import-boss/main.go -i k8s.io/gengo/... --verify-only
+        - go run ./examples/import-boss/main.go -i $(go list k8s.io/gengo/... | grep -v import-boss/tests | paste -sd',' -) --verify-only

--- a/examples/import-boss/Makefile
+++ b/examples/import-boss/Makefile
@@ -1,0 +1,28 @@
+TOOL=import-boss
+
+all: test
+
+test: build test_rules test_inverse
+
+build:
+	@go build -o /tmp/$(TOOL)
+
+test_rules:
+	  /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/rules/a)
+	! /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/rules/b)
+	  /tmp/$(TOOL) --logtostderr --v=4 -i ./tests/rules/c
+  	! /tmp/$(TOOL) --logtostderr --v=4 -i ./tests/rules/nested
+	  /tmp/$(TOOL) --logtostderr --v=4 -i ./tests/rules/nested/nested
+	! /tmp/$(TOOL) --logtostderr --v=4 -i ./tests/rules/nested/nested/nested
+	! /tmp/$(TOOL) --logtostderr --v=4 -i ./tests/rules/nested/nested/nested/inherit
+
+test_inverse:
+	  /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/inverse/a ./tests/inverse/lib/... | grep -v quarantine | paste -sd',' -)
+	! /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/inverse/b ./tests/inverse/lib/... | grep -v quarantine | paste -sd',' -)
+	  /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/inverse/c ./tests/inverse/lib/... | grep -v quarantine | paste -sd',' -)
+	! /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/inverse/d ./tests/inverse/lib/... | grep -v quarantine | paste -sd',' -)
+	! /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/inverse/lib/... | paste -sd',' -)
+
+	! /tmp/$(TOOL) --logtostderr --v=4 -i $$(go list ./tests/inverse/lib/... | paste -sd',' -)
+
+.PHONY: build test test_rules test_inverse

--- a/examples/import-boss/main.go
+++ b/examples/import-boss/main.go
@@ -21,19 +21,24 @@ limitations under the License.
 // recursively searched.
 //
 // If an ".import-restrictions" file is found, then all imports of the package
-// are checked against each "rule" in the file. A rule consists of three parts:
+// are checked against each "rule" in the file. It is accepted if it passes all
+// rules with a matching selector.
+//
+// A rule consists of three parts:
 // * A SelectorRegexp, to select the import paths that the rule applies to.
 // * A list of AllowedPrefixes
 // * A list of ForbiddenPrefixes
-// An import is allowed if it matches at least one allowed prefix and does not
-// match any forbidden prefix. An example file looks like this:
+// An import passes a rule of a matching selector if it matches at least one
+// allowed prefix, but no forbidden prefix.
+//
+// An example file looks like this:
 //
 // {
 //   "Rules": [
 //     {
 //       "SelectorRegexp": "k8s[.]io",
 //       "AllowedPrefixes": [
-//         "k8s.io/gengo",
+//         "k8s.io/gengo/examples",
 //         "k8s.io/kubernetes/third_party"
 //       ],
 //       "ForbiddenPrefixes": [
@@ -51,7 +56,7 @@ limitations under the License.
 //   ]
 // }
 //
-// Note the secound block explicitly matches the unsafe package, and forbids it
+// Note the second block explicitly matches the unsafe package, and forbids it
 // ("" is a prefix of everything).
 package main
 

--- a/examples/import-boss/main.go
+++ b/examples/import-boss/main.go
@@ -16,13 +16,15 @@ limitations under the License.
 
 // import-boss enforces import restrictions in a given repository.
 //
-// When a directory is verified, import-boss looks for a file called
-// ".import-restrictions". If this file is not found, parent directories will be
-// recursively searched.
+// When a package is verified, import-boss looks for files called
+// ".import-restrictions" in all directories between the package and
+// the $GOPATH/src.
 //
-// If an ".import-restrictions" file is found, then all imports of the package
-// are checked against each "rule" in the file. It is accepted if it passes all
-// rules with a matching selector.
+// All imports of the package are checked against each "rule" in the
+// found restriction files, climbing up the directory tree until the
+// import matches one of the rules.
+//
+// If the import does not match any of the rules, it is accepted.
 //
 // A rule consists of three parts:
 // * A SelectorRegexp, to select the import paths that the rule applies to.

--- a/examples/import-boss/main.go
+++ b/examples/import-boss/main.go
@@ -26,6 +26,12 @@ limitations under the License.
 //
 // If the import does not match any of the rules, it is accepted.
 //
+// In analogy, all incoming imports of the package are checked against each
+// "inverse rule" in the found restriction files, blimbing up the directory
+// tree until the import matches one of the rules.
+//
+// If the incoming import does not match any of the inverse rules, it is accepted.
+//
 // A rule consists of three parts:
 // * A SelectorRegexp, to select the import paths that the rule applies to.
 // * A list of AllowedPrefixes
@@ -55,11 +61,37 @@ limitations under the License.
 //         ""
 //       ]
 //     }
+//   ],
+//   "InverseRules": [{
+//       "SelectorRegexp": "k8s[.]io",
+//       "AllowedPrefixes": [
+//         "k8s.io/same-repo",
+//         "k8s.io/kubernetes/pkg/legacy"
+//       ],
+//       "ForbiddenPrefixes": [
+//         "k8s.io/kubernetes/pkg/legacy/subpkg"
+//       ]
+//     },
+//     {
+//       "SelectorRegexp": "k8s[.]io",
+//       "Transitive": true,
+//       "AllowedPrefixes": [
+//         "k8s.io/
+//       ],
+//       "ForbiddenPrefixes": [
+//         "k8s.io/kubernetes/cmd/kubelet",
+//         "k8s.io/kubernetes/cmd/kubectl"
+//       ],
 //   ]
 // }
 //
-// Note the second block explicitly matches the unsafe package, and forbids it
+// Note the second rule explicitly matches the unsafe package, and forbids it
 // ("" is a prefix of everything).
+//
+// An import from another package passes an inverse rule with a matching selector if
+// it matches at least one allowed prefix, but no forbidden prefix.
+//
+// Note that the second InverseRule is transitive, the first only applies to direct imports.
 package main
 
 import (

--- a/examples/import-boss/tests/inverse/a/doc.go
+++ b/examples/import-boss/tests/inverse/a/doc.go
@@ -1,0 +1,6 @@
+// a only imports public packages.
+package a
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/public"
+)

--- a/examples/import-boss/tests/inverse/b/doc.go
+++ b/examples/import-boss/tests/inverse/b/doc.go
@@ -1,0 +1,7 @@
+// b only imports public and private packages. The latter it shouldn't.
+package b
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/private"
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/public"
+)

--- a/examples/import-boss/tests/inverse/c/doc.go
+++ b/examples/import-boss/tests/inverse/c/doc.go
@@ -1,0 +1,7 @@
+// c imports the library root, which in turn imports the public and private packages. This is fine because
+// the private package is not directly imported.
+package c
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib"
+)

--- a/examples/import-boss/tests/inverse/d/doc.go
+++ b/examples/import-boss/tests/inverse/d/doc.go
@@ -1,0 +1,6 @@
+// c imports non-prod code. It shouldn't.
+package d
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/nonprod"
+)

--- a/examples/import-boss/tests/inverse/lib/doc.go
+++ b/examples/import-boss/tests/inverse/lib/doc.go
@@ -1,0 +1,6 @@
+package lib
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/private"
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/public"
+)

--- a/examples/import-boss/tests/inverse/lib/lib_test.go
+++ b/examples/import-boss/tests/inverse/lib/lib_test.go
@@ -1,0 +1,5 @@
+package lib
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/nonprod"
+)

--- a/examples/import-boss/tests/inverse/lib/nonprod/.import-restrictions
+++ b/examples/import-boss/tests/inverse/lib/nonprod/.import-restrictions
@@ -1,0 +1,9 @@
+{
+   "InverseRules": [{
+       "Transitive": true,
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/inverse/lib"
+       ]
+   }]
+}

--- a/examples/import-boss/tests/inverse/lib/nonprod/doc.go
+++ b/examples/import-boss/tests/inverse/lib/nonprod/doc.go
@@ -1,0 +1,2 @@
+// nonprod is non-production code that should not be linked into any outside package.
+package nonprod

--- a/examples/import-boss/tests/inverse/lib/private/.import-restrictions
+++ b/examples/import-boss/tests/inverse/lib/private/.import-restrictions
@@ -1,0 +1,11 @@
+{
+   "InverseRules": [{
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/inverse/lib"
+       ],
+       "ForbiddenPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/inverse/lib/quarantine"
+       ]
+   }]
+}

--- a/examples/import-boss/tests/inverse/lib/private/doc.go
+++ b/examples/import-boss/tests/inverse/lib/private/doc.go
@@ -1,0 +1,1 @@
+package private

--- a/examples/import-boss/tests/inverse/lib/public/doc.go
+++ b/examples/import-boss/tests/inverse/lib/public/doc.go
@@ -1,0 +1,1 @@
+package public

--- a/examples/import-boss/tests/inverse/lib/quarantine/doc.go
+++ b/examples/import-boss/tests/inverse/lib/quarantine/doc.go
@@ -1,0 +1,6 @@
+// quarantine is inside the library, but should not import the private package. But it does!
+package quarantine
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/inverse/lib/private"
+)

--- a/examples/import-boss/tests/rules/a/.import-restrictions
+++ b/examples/import-boss/tests/rules/a/.import-restrictions
@@ -1,0 +1,11 @@
+{
+   "Rules": [{
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/rules/b"
+       ],
+       "ForbiddenPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/rules/c"
+       ]
+   }]
+}

--- a/examples/import-boss/tests/rules/a/doc.go
+++ b/examples/import-boss/tests/rules/a/doc.go
@@ -1,0 +1,5 @@
+package a
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/rules/b"
+)

--- a/examples/import-boss/tests/rules/b/.import-restrictions
+++ b/examples/import-boss/tests/rules/b/.import-restrictions
@@ -1,0 +1,11 @@
+{
+   "Rules": [{
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+         ""
+       ],
+       "ForbiddenPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/rules/c"
+       ]
+   }]
+}

--- a/examples/import-boss/tests/rules/b/doc.go
+++ b/examples/import-boss/tests/rules/b/doc.go
@@ -1,0 +1,6 @@
+// b only public and private packages. The latter it shouldn't.
+package b
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/rules/c"
+)

--- a/examples/import-boss/tests/rules/c/doc.go
+++ b/examples/import-boss/tests/rules/c/doc.go
@@ -1,0 +1,1 @@
+package c

--- a/examples/import-boss/tests/rules/nested/.import-restrictions
+++ b/examples/import-boss/tests/rules/nested/.import-restrictions
@@ -1,0 +1,10 @@
+{
+   "Rules": [{
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+       ],
+       "ForbiddenPrefixes": [
+         "k8s.io/gengo/examples/import-boss/tests/rules/c"
+       ]
+   }]
+}

--- a/examples/import-boss/tests/rules/nested/doc.go
+++ b/examples/import-boss/tests/rules/nested/doc.go
@@ -1,0 +1,5 @@
+package nested
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/rules/c"
+)

--- a/examples/import-boss/tests/rules/nested/nested/.import-restrictions
+++ b/examples/import-boss/tests/rules/nested/nested/.import-restrictions
@@ -1,0 +1,10 @@
+{
+   "Rules": [{
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+           "k8s.io/gengo/examples/import-boss/tests/rules/c"
+       ],
+       "ForbiddenPrefixes": [
+       ]
+   }]
+}

--- a/examples/import-boss/tests/rules/nested/nested/doc.go
+++ b/examples/import-boss/tests/rules/nested/nested/doc.go
@@ -1,0 +1,5 @@
+package nested
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/rules/c"
+)

--- a/examples/import-boss/tests/rules/nested/nested/nested/.import-restrictions
+++ b/examples/import-boss/tests/rules/nested/nested/nested/.import-restrictions
@@ -1,0 +1,10 @@
+{
+   "Rules": [{
+       "SelectorRegexp": "k8s[.]io/gengo",
+       "AllowedPrefixes": [
+       ],
+       "ForbiddenPrefixes": [
+            "k8s.io/gengo/examples/import-boss/tests/rules/c"
+       ]
+   }]
+}

--- a/examples/import-boss/tests/rules/nested/nested/nested/doc.go
+++ b/examples/import-boss/tests/rules/nested/nested/nested/doc.go
@@ -1,0 +1,5 @@
+package nested
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/rules/c"
+)

--- a/examples/import-boss/tests/rules/nested/nested/nested/inherit/doc.go
+++ b/examples/import-boss/tests/rules/nested/nested/nested/inherit/doc.go
@@ -1,0 +1,5 @@
+package inherit
+
+import (
+	_ "k8s.io/gengo/examples/import-boss/tests/rules/c"
+)

--- a/generator/execute.go
+++ b/generator/execute.go
@@ -236,6 +236,7 @@ func (c *Context) ExecutePackage(outDir string, p Package) error {
 				Name:        g.Filename(),
 				FileType:    fileType,
 				PackageName: p.Name(),
+				PackagePath: p.Path(),
 				Header:      p.Header(g.Filename()),
 				Imports:     map[string]struct{}{},
 			}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -54,6 +54,7 @@ type File struct {
 	FileType    string
 	PackageName string
 	Header      []byte
+	PackagePath string
 	Imports     map[string]struct{}
 	Vars        bytes.Buffer
 	Consts      bytes.Buffer

--- a/generator/transitive_closure.go
+++ b/generator/transitive_closure.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+type edge struct {
+	from string
+	to   string
+}
+
+func transitiveClosure(in map[string][]string) map[string][]string {
+	adj := make(map[edge]bool)
+	imports := make(map[string]struct{})
+	for from, tos := range in {
+		for _, to := range tos {
+			adj[edge{from, to}] = true
+			imports[to] = struct{}{}
+		}
+	}
+
+	// Warshal's algorithm
+	for k := range in {
+		for i := range in {
+			if !adj[edge{i, k}] {
+				continue
+			}
+			for j := range imports {
+				if adj[edge{i, j}] {
+					continue
+				}
+				if adj[edge{k, j}] {
+					adj[edge{i, j}] = true
+				}
+			}
+		}
+	}
+
+	out := make(map[string][]string, len(in))
+	for i := range in {
+		for j := range imports {
+			if adj[edge{i, j}] {
+				out[i] = append(out[i], j)
+			}
+		}
+	}
+
+	return out
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -403,7 +403,7 @@ func (b *Builder) typeCheckPackage(pkgPath importPathString) (*tc.Package, error
 	}
 	parsedFiles, ok := b.parsed[pkgPath]
 	if !ok {
-		return nil, fmt.Errorf("No files for pkg %q: %#v", pkgPath, b.parsed)
+		return nil, fmt.Errorf("no files for pkg %q", pkgPath)
 	}
 	files := make([]*ast.File, len(parsedFiles))
 	for i := range parsedFiles {


### PR DESCRIPTION
Allow to restrict which packages Y may import a given package X via `InverseRules` in `X/.import-restrictions`:

```
//   "InverseRules": [{
//       "SelectorRegexp": "k8s[.]io",
//       "AllowedPrefixes": [
//         "k8s.io/same-repo",
//         "k8s.io/kubernetes/pkg/legacy"
//       ],
//       "ForbiddenPrefixes": [
//         "k8s.io/kubernetes/pkg/legacy/subpkg"
//       ]
//     },
//     {
//       "SelectorRegexp": "k8s[.]io",
//       "Transitive": true,
//       "AllowedPrefixes": [
//         "k8s.io/
//       ],
//       "ForbiddenPrefixes": [
//         "k8s.io/kubernetes/cmd/kubelet",
//         "k8s.io/kubernetes/cmd/kubectl"
//       ],
//   ]
// }
```

Example use-cases:
- k8s.io/apiserver/pkg/features feature gates should not leak into kubectl and kubelet (e.g. for https://github.com/kubernetes/kubernetes/pull/65558).
- k8s.io/kubernetes/pkg/master should only be imported transitively by cmd/kube-apiserver and cmd/hyperkube.
- k8s.io/apimachinery/pkg/private should only be imported directly by k8s.io/apimachinery, with the legacy exceptions a, b, c.