### PR TITLE
go-to-protobuf: only make named types with package global

### DIFF
--- a/examples/go-to-protobuf/protobuf/namer.go
+++ b/examples/go-to-protobuf/protobuf/namer.go
@@ -116,7 +116,10 @@ func assignGoTypeToProtoPackage(p *protobufPackage, t *types.Type, local, global
 		}
 		return
 	}
-	global[t.Name] = p
+	if len(t.Name.Package) > 0 {
+		// remember named types only with a package
+		global[t.Name] = p
+	}
 	if _, ok := local[t.Name]; ok {
 		return
 	}


### PR DESCRIPTION
Otherwise, the first occurance of e.g. "*string" will be made global, introducing import dependencies to totally unrelated package in the produced .proto files.