### PR TITLE
examples/deepcopy-gen: Document doc.go requirement for =package

### DIFF
--- a/examples/deepcopy-gen/main.go
+++ b/examples/deepcopy-gen/main.go
@@ -32,7 +32,7 @@ limitations under the License.
 //
 // All generation is governed by comment tags in the source.  Any package may
 // request DeepCopy generation by including a comment in the file-comments of
-// one file, of the form:
+// a doc.go file, of the form:
 //   // +k8s:deepcopy-gen=package
 //
 // DeepCopy functions can be generated for individual types, rather than the


### PR DESCRIPTION
I spent too long scratching my head wondering why I was getting:

```console
$ deepcopy-gen -i . --logtostderr --v 5
...
I0918 13:34:13.110855   17959 deepcopy.go:146] Considering pkg "github.com/openshift/installer/pkg/ipnet"
I0918 13:34:13.110870   17959 deepcopy.go:164]   no tag
I0918 13:34:13.110878   17959 deepcopy.go:173]   considering type "github.com/openshift/installer/pkg/ipnet.IPNet"
I0918 13:34:13.110892   17959 main.go:87] Completed successfully.
```

despite:

```console
$ head -n4 ipnet.go
// +k8s:deepcopy-gen=package

// Package ipnet wraps net.IPNet to get CIDR serialization.
package ipnet
```

It looks like only `doc.go` has been checked for file-level comments since the initial commit in this repository df39b41e (2015-10-15).

Personally, I'd prefer if this tag could live in any file, but I haven't done the legwork to know if lifting the `doc.go` restriction would have accidental side-effects or not.