### PR TITLE
Fix some typos in example

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -326,7 +326,7 @@ func deepCopyMethod(t *types.Type) (*types.Signature, error) {
 	return f.Signature, nil
 }
 
-// deepCopyMethodOrDie returns the signatrue of a DeepCopy method, nil or calls klog.Fatalf
+// deepCopyMethodOrDie returns the signature of a DeepCopy method, nil or calls klog.Fatalf
 // if the type does not match.
 func deepCopyMethodOrDie(t *types.Type) *types.Signature {
 	ret, err := deepCopyMethod(t)

--- a/examples/deepcopy-gen/main.go
+++ b/examples/deepcopy-gen/main.go
@@ -36,7 +36,7 @@ limitations under the License.
 //   // +k8s:deepcopy-gen=package
 //
 // DeepCopy functions can be generated for individual types, rather than the
-// entire package by specifying a comment on the type definion of the form:
+// entire package by specifying a comment on the type definition of the form:
 //   // +k8s:deepcopy-gen=true
 //
 // When generating for a whole package, individual types may opt out of

--- a/examples/import-boss/main.go
+++ b/examples/import-boss/main.go
@@ -51,7 +51,7 @@ limitations under the License.
 //   ]
 // }
 //
-// Note the secound block explicitly matches the unsafe package, and forbids it
+// Note the second block explicitly matches the unsafe package, and forbids it
 // ("" is a prefix of everything).
 package main
 

--- a/generator/snippet_writer.go
+++ b/generator/snippet_writer.go
@@ -57,7 +57,7 @@ func NewSnippetWriter(w io.Writer, c *Context, left, right string) *SnippetWrite
 
 // Do parses format and runs args through it. You can have arbitrary logic in
 // the format (see the text/template documentation), but consider running many
-// short templaces, with ordinary go logic in between--this may be more
+// short templates, with ordinary go logic in between--this may be more
 // readable. Do is chainable. Any error causes every other call to do to be
 // ignored, and the error will be returned by Error(). So you can check it just
 // once, at the end of your function.


### PR DESCRIPTION
Fix some typos in example files:

1. examples/deepcopy-gen/generators/deepcopy.go
2. examples/deepcopy-gen/main.go