### PR TITLE
parser: remove possibly really long error message

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -403,7 +403,7 @@ func (b *Builder) typeCheckPackage(pkgPath importPathString) (*tc.Package, error
 	}
 	parsedFiles, ok := b.parsed[pkgPath]
 	if !ok {
-		return nil, fmt.Errorf("No files for pkg %q: %#v", pkgPath, b.parsed)
+		return nil, fmt.Errorf("No files for pkg %q", pkgPath)
 	}
 	files := make([]*ast.File, len(parsedFiles))
 	for i := range parsedFiles {

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -200,7 +200,7 @@ var FooAnotherVar proto.Frobber = proto.AnotherVar
 		t.Errorf("Wanted, got:\n%v\n-----\n%v\n", e, a)
 	}
 	if p := u.Package("base/foo/proto"); !p.HasImport("base/common/proto") {
-		t.Errorf("Unexpected lack of import line: %s", p.Imports)
+		t.Errorf("Unexpected lack of import line: %#v", p.Imports)
 	}
 }
 


### PR DESCRIPTION
This %#v caused an error text that's 186kb when printed. Also probably don't
need to dump the entire object's state along with its references with the
bunch of ast info as warning.

The error I got started like:

  W0106 17:57:01.925659 96841 parse.go:239] Ignoring child directory github.com/knative/build/pkg/apis/build/v1alpha1/testdata/cloudbuilders/yarn: No files for pkg "github.com/knative/build/pkg/apis/build/v1alpha1/testdata/cloudbuilders/yarn" [...+186 kb]