### PR TITLE
Fix Code gen bug that generates invalid code if struct has _.

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -823,6 +823,9 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 
 	// Now fix-up fields as needed.
 	for _, m := range ut.Members {
+		if m.Name == "_" {
+			continue
+		}
 		ft := m.Type
 		uft := underlyingType(ft)
 


### PR DESCRIPTION
Fixes bug - https://github.com/kubernetes/gengo/issues/133 

The Issue has full detail from @cholman-zd and this one just lifts the ability to skip `_` fields so the codegen does not hiccup.