### PR TITLE
fix: Don't generate reserved identifiers or keywords as local package…

### DIFF
--- a/generator/import_tracker.go
+++ b/generator/import_tracker.go
@@ -58,7 +58,8 @@ func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 			// This name collides with some other package
 			continue
 		}
-		return name
+		// This name can be a reserved identifier or a keyword
+		return "_" + name
 	}
 	panic("can't find import for " + path)
 }


### PR DESCRIPTION
… names

The basename of a package import pathe can be a reserved identifier or
a keyword as in "butwhy/type" which would have resulted in the
following generated code:

  import type "butwhy/type"

To avoid this scenario local package names are prefixed with an
underscore.