### PR TITLE
deepcopy: error out on interface{}

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -745,6 +745,10 @@ func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
 	case uet.IsAssignable():
 		sw.Do("(*out)[key] = val\n", nil)
 	case uet.Kind == types.Interface:
+		// Note: do not generate code that won't compile as `DeepCopyinterface{}()` is not a valid function
+		if uet.Name.Name == "interface{}" {
+			klog.Fatalf("DeepCopy of %q is unsupported. Instead, use named interfaces with DeepCopy<named-interface> as one of the methods.", uet.Name.Name)
+		}
 		sw.Do("if val == nil {(*out)[key]=nil} else {\n", nil)
 		// Note: if t.Elem has been an alias "J" of an interface "I" in Go, we will see it
 		// as kind Interface of name "J" here, i.e. generate val.DeepCopyJ(). The golang
@@ -793,6 +797,10 @@ func (g *genDeepCopy) doSlice(t *types.Type, sw *generator.SnippetWriter) {
 			g.generateFor(ut.Elem, sw)
 			sw.Do("}\n", nil)
 		} else if uet.Kind == types.Interface {
+			// Note: do not generate code that won't compile as `DeepCopyinterface{}()` is not a valid function
+			if uet.Name.Name == "interface{}" {
+				klog.Fatalf("DeepCopy of %q is unsupported. Instead, use named interfaces with DeepCopy<named-interface> as one of the methods.", uet.Name.Name)
+			}
 			sw.Do("if (*in)[i] != nil {\n", nil)
 			// Note: if t.Elem has been an alias "J" of an interface "I" in Go, we will see it
 			// as kind Interface of name "J" here, i.e. generate val.DeepCopyJ(). The golang
@@ -863,6 +871,10 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 				sw.Do("in.$.name$.DeepCopyInto(&out.$.name$)\n", args)
 			}
 		case uft.Kind == types.Interface:
+			// Note: do not generate code that won't compile as `DeepCopyinterface{}()` is not a valid function
+			if uft.Name.Name == "interface{}" {
+				klog.Fatalf("DeepCopy of %q is unsupported. Instead, use named interfaces with DeepCopy<named-interface> as one of the methods.", uft.Name.Name)
+			}
 			sw.Do("if in.$.name$ != nil {\n", args)
 			// Note: if t.Elem has been an alias "J" of an interface "I" in Go, we will see it
 			// as kind Interface of name "J" here, i.e. generate val.DeepCopyJ(). The golang


### PR DESCRIPTION
Instead of generating code that does not compile, error out immediately
when generateFor gets called with `interface{}`

This relates to #138 

This PR lacks testing for this: I'll need some guidance around this please.

I currently see two ways to do this:

* factorize the code that handles the interface type and unit-test this function
* add another type of end-to-end test, this time making sure that `deepcopy-gen` fails. This one seems a bit brittle as the cause of failure would need to be checked for the test to be effective.
