### PR TITLE
 Sets: Make Insert and Delete return the Set

### DIFF
--- a/examples/set-gen/generators/sets.go
+++ b/examples/set-gen/generators/sets.go
@@ -205,17 +205,19 @@ func $.type|public$KeySet(theMap interface{}) $.type|public$ {
 }
 
 // Insert adds items to the set.
-func (s $.type|public$) Insert(items ...$.type|raw$) {
+func (s $.type|public$) Insert(items ...$.type|raw$) $.type|public$ {
 	for _, item := range items {
 		s[item] = Empty{}
 	}
+	return s
 }
 
 // Delete removes all items from the set.
-func (s $.type|public$) Delete(items ...$.type|raw$) {
+func (s $.type|public$) Delete(items ...$.type|raw$) $.type|public$ {
 	for _, item := range items {
 		delete(s, item)
 	}
+	return s
 }
 
 // Has returns true if and only if item is contained in the set.

--- a/examples/set-gen/sets/byte.go
+++ b/examples/set-gen/sets/byte.go
@@ -46,17 +46,19 @@ func ByteKeySet(theMap interface{}) Byte {
 }
 
 // Insert adds items to the set.
-func (s Byte) Insert(items ...byte) {
+func (s Byte) Insert(items ...byte) Byte {
 	for _, item := range items {
 		s[item] = Empty{}
 	}
+	return s
 }
 
 // Delete removes all items from the set.
-func (s Byte) Delete(items ...byte) {
+func (s Byte) Delete(items ...byte) Byte {
 	for _, item := range items {
 		delete(s, item)
 	}
+	return s
 }
 
 // Has returns true if and only if item is contained in the set.

--- a/examples/set-gen/sets/int.go
+++ b/examples/set-gen/sets/int.go
@@ -46,17 +46,19 @@ func IntKeySet(theMap interface{}) Int {
 }
 
 // Insert adds items to the set.
-func (s Int) Insert(items ...int) {
+func (s Int) Insert(items ...int) Int {
 	for _, item := range items {
 		s[item] = Empty{}
 	}
+	return s
 }
 
 // Delete removes all items from the set.
-func (s Int) Delete(items ...int) {
+func (s Int) Delete(items ...int) Int {
 	for _, item := range items {
 		delete(s, item)
 	}
+	return s
 }
 
 // Has returns true if and only if item is contained in the set.

--- a/examples/set-gen/sets/int64.go
+++ b/examples/set-gen/sets/int64.go
@@ -46,17 +46,19 @@ func Int64KeySet(theMap interface{}) Int64 {
 }
 
 // Insert adds items to the set.
-func (s Int64) Insert(items ...int64) {
+func (s Int64) Insert(items ...int64) Int64 {
 	for _, item := range items {
 		s[item] = Empty{}
 	}
+	return s
 }
 
 // Delete removes all items from the set.
-func (s Int64) Delete(items ...int64) {
+func (s Int64) Delete(items ...int64) Int64 {
 	for _, item := range items {
 		delete(s, item)
 	}
+	return s
 }
 
 // Has returns true if and only if item is contained in the set.

--- a/examples/set-gen/sets/string.go
+++ b/examples/set-gen/sets/string.go
@@ -46,17 +46,19 @@ func StringKeySet(theMap interface{}) String {
 }
 
 // Insert adds items to the set.
-func (s String) Insert(items ...string) {
+func (s String) Insert(items ...string) String {
 	for _, item := range items {
 		s[item] = Empty{}
 	}
+	return s
 }
 
 // Delete removes all items from the set.
-func (s String) Delete(items ...string) {
+func (s String) Delete(items ...string) String {
 	for _, item := range items {
 		delete(s, item)
 	}
+	return s
 }
 
 // Has returns true if and only if item is contained in the set.


### PR DESCRIPTION
 Sets: Make Insert and Delete return the Set
    
Sets in its current form is already very useful, however sometimes it is
awkward to use. Consider the following example:
    
```
// Removes a finalizer if it exists
finalizers := sets.NewString(obj.GetFinalizers()...)
sets.Delete(toRemove)
obj.SetFinalizers(set.List())
```
    
With this patch, the above example could be solved in one line:
    
```
obj.SetFinalizers(sets.NewString(obj.GetFinalizers()...).Delete(toDelete).List())
```

Result of discussion in https://github.com/kubernetes/kubernetes/pull/81234

/assign @lavalamp 