### PR TITLE
Support importing packages with reserved names.

### DIFF
--- a/generator/import_tracker.go
+++ b/generator/import_tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generator
 
 import (
+	"go/token"
 	"strings"
 
 	"k8s.io/klog"
@@ -57,6 +58,11 @@ func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 		if _, found := tracker.PathOf(name); found {
 			// This name collides with some other package
 			continue
+		}
+
+		// If the import name is a Go keyword, prefix with an underscore.
+		if token.Lookup(name).IsKeyword() {
+			name = "_" + name
 		}
 		return name
 	}

--- a/generator/import_tracker_test.go
+++ b/generator/import_tracker_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/gengo/types"
+)
+
+func TestNewImportTracker(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputTypes      []*types.Type
+		expectedImports []string
+	}{
+		{
+			name:            "empty",
+			inputTypes:      []*types.Type{},
+			expectedImports: []string{},
+		},
+		{
+			name: "builtin",
+			inputTypes: []*types.Type{
+				{Name: types.Name{Package: "net/http"}},
+			},
+			expectedImports: []string{
+				`http "net/http"`,
+			},
+		},
+		{
+			name: "sorting",
+			inputTypes: []*types.Type{
+				{Name: types.Name{Package: "foo/bar/pkg2"}},
+				{Name: types.Name{Package: "foo/bar/pkg1"}},
+			},
+			expectedImports: []string{
+				`pkg1 "foo/bar/pkg1"`,
+				`pkg2 "foo/bar/pkg2"`,
+			},
+		},
+		{
+			name: "reserved-keyword",
+			inputTypes: []*types.Type{
+				{Name: types.Name{Package: "my/reserved/pkg/struct"}},
+			},
+			expectedImports: []string{
+				`_struct "my/reserved/pkg/struct"`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualImports := NewImportTracker(tt.inputTypes...).ImportLines()
+			if !reflect.DeepEqual(actualImports, tt.expectedImports) {
+				t.Errorf("ImportLines(%v) = %v, want %v", tt.inputTypes, actualImports, tt.expectedImports)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for importing packages such as [`github.com/golang/protobuf/ptypes/struct`](https://godoc.org/github.com/golang/protobuf/ptypes/struct) which collide with a Go keyword.

This is a more precise version of https://github.com/kubernetes/gengo/pull/135, which only adds an underscore prefix for import names which are Go reserved keywords (using the `go/token` package).

cc @sttts @pbarker