### PR TITLE
Fixes nil panic on unknown types

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -248,7 +248,11 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		shouldCreateObjectDefaulterFn := func(t *types.Type) bool {
 			if defaults, ok := existingDefaulters[t]; ok && defaults.object != nil {
 				// A default generator is defined
-				klog.V(5).Infof("  an object defaulter already exists as %s", defaults.base.Name)
+				baseTypeName := "<unknown>"
+				if defaults.base != nil {
+					baseTypeName = defaults.base.Name.String()
+				}
+				klog.V(5).Infof("  an object defaulter already exists as %s", baseTypeName)
 				return false
 			}
 			// opt-out


### PR DESCRIPTION
defaulter-gen is panic'ing on printing an INFO log in our customized usage. this prints `<unknown>` instead of nil-panic.

```
2019/09/06 18:01:29 failed to run defaulter-gen panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1262816]

goroutine 1 [running]:
sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/vendor/k8s.io/gengo/examples/defaulter-gen/generators.Packages.func1(0xc011fbf8c0, 0xc009fb8b00)
        /Users/zuoxiu.jm/go/src/sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go:251 +0x406
sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/vendor/k8s.io/gengo/examples/defaulter-gen/generators.Packages(0xc013a33b00, 0xc0000cc460, 0x12fdd91, 0x6, 0xc013a33b00)
        /Users/zuoxiu.jm/go/src/sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go:297 +0x8bd
sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/vendor/k8s.io/gengo/args.(*GeneratorArgs).Execute(0xc0000cc460, 0xc0000cac30, 0x12fdd91, 0x6, 0x1338560, 0x0, 0x0)
        /Users/zuoxiu.jm/go/src/sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/vendor/k8s.io/gengo/args/args.go:193 +0x291
main.main()
        /Users/zuoxiu.jm/go/src/sigs.k8s.io/apiserver-builder-alpha/cmd/vendor/k8s.io/code-generator/cmd/defaulter-gen/main.go:75 +0x2dd
 exit status 2
```