### PR TITLE
Add constant support

### DIFF
--- a/namer/order.go
+++ b/namer/order.go
@@ -43,6 +43,9 @@ func (o *Orderer) OrderUniverse(u types.Universe) []*types.Type {
 		for _, v := range p.Variables {
 			list.types = append(list.types, v)
 		}
+		for _, v := range p.Constants {
+			list.types = append(list.types, v)
+		}
 	}
 	sort.Sort(list)
 	return list.types

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -548,6 +548,10 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 		if ok && !tv.IsField() {
 			b.addVariable(*u, nil, tv)
 		}
+		tconst, ok := obj.(*tc.Const)
+		if ok {
+			b.addConstant(*u, nil, tconst)
+		}
 	}
 
 	importedPkgs := []string{}
@@ -810,6 +814,17 @@ func (b *Builder) addVariable(u types.Universe, useName *types.Name, in *tc.Var)
 		name = *useName
 	}
 	out := u.Variable(name)
+	out.Kind = types.DeclarationOf
+	out.Underlying = b.walkType(u, nil, in.Type())
+	return out
+}
+
+func (b *Builder) addConstant(u types.Universe, useName *types.Name, in *tc.Const) *types.Type {
+	name := tcVarNameToName(in.String())
+	if useName != nil {
+		name = *useName
+	}
+	out := u.Constant(name)
 	out.Kind = types.DeclarationOf
 	out.Underlying = b.walkType(u, nil, in.Type())
 	return out

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/parser"
@@ -154,6 +156,11 @@ func TestBuilder(t *testing.T) {
                 var (
 	                AnotherVar = Frobber{}
                 )
+
+				type Enumeration string
+				const (
+					EnumSymbol Enumeration = "enumSymbol"
+				)
                 `,
 		},
 	}
@@ -172,12 +179,17 @@ package o
 {{define "Var"}}{{$t := .Underlying}}var {{Name .}} {{Raw $t}} = {{Raw .}}
 
 {{end}}
+{{define "Const"}}{{$t := .Underlying}}const {{Name .}} {{Raw $t}} = {{Raw .}}
+
+{{end}}
 {{range $t := .}}{{if eq $t.Kind "Struct"}}{{template "Struct" $t}}{{end}}{{end}}
 {{range $t := .}}{{if eq $t.Kind "DeclarationOf"}}{{if eq $t.Underlying.Kind "Func"}}{{template "Func" $t}}{{end}}{{end}}{{end}}
-{{range $t := .}}{{if eq $t.Kind "DeclarationOf"}}{{if ne $t.Underlying.Kind "Func"}}{{template "Var" $t}}{{end}}{{end}}{{end}}`
+{{range $t := .}}{{if eq $t.Kind "DeclarationOf"}}{{if eq $t.Underlying.Kind "Struct"}}{{template "Var" $t}}{{end}}{{end}}{{end}}
+{{range $t := .}}{{if eq $t.Kind "DeclarationOf"}}{{if eq $t.Underlying.Kind "Alias"}}{{template "Const" $t}}{{end}}{{end}}{{end}}`
 
 	var expect = `
 package o
+
 
 
 
@@ -215,6 +227,9 @@ var FooAVar proto.Frobber = proto.AVar
 
 var FooAnotherVar proto.Frobber = proto.AnotherVar
 
+
+const FooEnumSymbol proto.Enumeration = proto.EnumSymbol
+
 `
 	testNamer := namer.NewPublicNamer(1, "proto")
 	rawNamer := namer.NewRawNamer("o", nil)
@@ -232,7 +247,8 @@ var FooAnotherVar proto.Frobber = proto.AnotherVar
 	buf := &bytes.Buffer{}
 	tmpl.Execute(buf, o)
 	if e, a := expect, buf.String(); e != a {
-		t.Errorf("Wanted, got:\n%v\n-----\n%v\n", e, a)
+		cmp.Diff(e, a)
+		t.Errorf("Wanted, got:\n%v\n-----\n%v\nDiff:\n%s", e, a, cmp.Diff(e, a))
 	}
 	if p := u.Package("base/foo/proto"); !p.HasImport("base/common/proto") {
 		t.Errorf("Unexpected lack of import line: %#v", p.Imports)


### PR DESCRIPTION
This is a pre-requisite for being able to support enums in OpenAPI where the types.go declaration uses constants, e.g.:

```
// MatchPolicyType specifies the type of match policy
type MatchPolicyType string

const (
	// Exact means requests should only be sent to the webhook if they exactly match a given rule
	Exact MatchPolicyType = "Exact"
	// Equivalent means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
	Equivalent MatchPolicyType = "Equivalent"
)
```