### PR TITLE
Use UTC for calculation of year

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -112,7 +112,7 @@ func (g *GeneratorArgs) LoadGoBoilerplate() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	b = bytes.Replace(b, []byte("YEAR"), []byte(strconv.Itoa(time.Now().Year())), -1)
+	b = bytes.Replace(b, []byte("YEAR"), []byte(strconv.Itoa(time.Now().UTC().Year())), -1)
 
 	if g.GeneratedByCommentTemplate != "" {
 		if len(b) != 0 {


### PR DESCRIPTION
/kind bug

In the evening/night of December 31 in the Western hemisphere, gengo will create output that fails CI validation.
