### PR TITLE
Use YAML format for import-restrictions

### DIFF
--- a/.import-restrictions
+++ b/.import-restrictions
@@ -4,7 +4,8 @@
       "SelectorRegexp": "k8s[.]io",
       "AllowedPrefixes": [
         "k8s.io/gengo",
-        "k8s.io/klog"
+        "k8s.io/klog",
+        "sigs.k8s.io/yaml"
       ]
     }
   ]

--- a/examples/import-boss/generators/import_restrict.go
+++ b/examples/import-boss/generators/import_restrict.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/klog"
 )
@@ -120,7 +121,7 @@ func readFile(path string) (*fileFormat, error) {
 	}
 
 	var current fileFormat
-	err = json.Unmarshal(currentBytes, &current)
+	err = yaml.Unmarshal(currentBytes, &current)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal %v: %v", path, err)
 	}


### PR DESCRIPTION
As suggested by @sttts, this will enable us add comments to import-restrictions files giving explanations for some import restrictions that we add.