### PR TITLE
Add interface method comment lines

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -750,7 +750,10 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 			if out.Methods == nil {
 				out.Methods = map[string]*types.Type{}
 			}
-			out.Methods[t.Method(i).Name()] = b.walkType(u, nil, t.Method(i).Type())
+			method := t.Method(i)
+			mt := b.walkType(u, nil, method.Type())
+			mt.CommentLines = splitLines(b.priorCommentLines(method.Pos(), 1).Text())
+			out.Methods[method.Name()] = mt
 		}
 		return out
 	case *tc.Named:

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -364,6 +364,19 @@ func TestParseMethodCommentLines(t *testing.T) {
                     `},
 			expected: []string{"BlahFunc's CommentLines.", "Another line."},
 		},
+		{
+			testFile: file{
+				path: fileName, contents: `
+				    package foo
+
+                    type Blah interface {
+	                    // BlahFunc's CommentLines.
+	                    // Another line.
+	                    BlahFunc()
+                    }
+                    `},
+			expected: []string{"BlahFunc's CommentLines.", "Another line."},
+		},
 	}
 	for _, test := range testCases {
 		_, u, o := construct(t, []file{test.testFile}, namer.NewPublicNamer(0))
@@ -371,7 +384,7 @@ func TestParseMethodCommentLines(t *testing.T) {
 		blahT := u.Type(types.Name{Package: "base/foo/proto", Name: "Blah"})
 		blahM := blahT.Methods["BlahFunc"]
 		if e, a := test.expected, blahM.CommentLines; !reflect.DeepEqual(e, a) {
-			t.Errorf("struct method comment wrong, wanted %q, got %q", e, a)
+			t.Errorf("method comment wrong, wanted %q, got %q", e, a)
 		}
 	}
 }


### PR DESCRIPTION
Recording comment lines of methods in a interface is useful for writing a customized generator.
