### PR TITLE
reduce noise in import-boss log output

### DIFF
--- a/parser/local_parse_test.go
+++ b/parser/local_parse_test.go
@@ -36,6 +36,13 @@ func TestImportBuildPackage(t *testing.T) {
 	}
 }
 
+func TestIsErrPackageNotFound(t *testing.T) {
+	b := New()
+	if _, err := b.importBuildPackage("fake/empty"); !isErrPackageNotFound(err) {
+		t.Fatal(err)
+	}
+}
+
 func TestCanonicalizeImportPath(t *testing.T) {
 	tcs := []struct {
 		name   string


### PR DESCRIPTION
Running import-boss on Kubernetes produces hundreds of instances of logs like below which increases noise in log output:
`
W0117 19:40:19.480385  296076 parse.go:246] Ignoring child directory k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms: unable to import "k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms": cannot find package "k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms" in any of:
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms (vendor tree)
	/usr/local/go/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms (from $GOROOT)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms (from $GOPATH)
`

This specific error occurs when there is no go source in a package and subpackages.

This PR logs the error with higher verbosity which reduces log ouput noise.