### PR TITLE
Convert path to slashes before passing to build.Context.Import()

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -589,7 +589,7 @@ func (b *Builder) importWithMode(dir string, mode build.ImportMode) (*build.Pack
 	if err != nil {
 		return nil, fmt.Errorf("unable to get current directory: %v", err)
 	}
-	buildPkg, err := b.context.Import(dir, cwd, mode)
+	buildPkg, err := b.context.Import(filepath.ToSlash(dir), cwd, mode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On UNIX systems, we get away with the existing code because filesystem
and package paths both use the same kind of separator.  On Windows,
sadly, that isn't the case and that causes everything to go wrong
(more specifically, we end up not being able to detect that this is a
local package, and so the output path for the generated files is
wrong).

Fixes issue #166.