### PR TITLE
fix method with same sigature comments mismatch

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -763,7 +763,8 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 				out.Methods = map[string]*types.Type{}
 			}
 			method := t.Method(i)
-			mt := b.walkType(u, nil, method.Type())
+			name := tcNameToName(method.String())
+			mt := b.walkType(u, &name, method.Type())
 			mt.CommentLines = splitLines(b.priorCommentLines(method.Pos(), 1).Text())
 			out.Methods[method.Name()] = mt
 		}
@@ -798,7 +799,8 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 					out.Methods = map[string]*types.Type{}
 				}
 				method := t.Method(i)
-				mt := b.walkType(u, nil, method.Type())
+				name := tcNameToName(method.String())
+				mt := b.walkType(u, &name, method.Type())
 				mt.CommentLines = splitLines(b.priorCommentLines(method.Pos(), 1).Text())
 				out.Methods[method.Name()] = mt
 			}


### PR DESCRIPTION
Fix:
Different methods with same signature will get same commentLines.