### PR TITLE
fix tcNameToName

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -628,7 +628,7 @@ func tcNameToName(in string) types.Name {
 		strings.HasPrefix(in, "<-chan") ||
 		strings.HasPrefix(in, "chan<-") ||
 		strings.HasPrefix(in, "chan ") ||
-		strings.HasPrefix(in, "func(") ||
+		strings.HasPrefix(in, "func (") ||
 		strings.HasPrefix(in, "*") ||
 		strings.HasPrefix(in, "map[") ||
 		strings.HasPrefix(in, "[") {


### PR DESCRIPTION
if type is method, format of `in` will be `func (a x) method(){}`, missing space before `(`