### PR TITLE
Capture the values of constant declarations.

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/build"
+	"go/constant"
 	"go/parser"
 	"go/token"
 	tc "go/types"
@@ -848,6 +849,22 @@ func (b *Builder) addConstant(u types.Universe, useName *types.Name, in *tc.Cons
 	out := u.Constant(name)
 	out.Kind = types.DeclarationOf
 	out.Underlying = b.walkType(u, nil, in.Type())
+
+	var constval string
+
+	// For strings, we use `StringVal()` to get the un-truncated,
+	// un-quoted string. For other values, `.String()` is preferable to
+	// get something relatively human readable (especially since for
+	// floating point types, `ExactString()` will generate numeric
+	// expressions using `big.(*Float).Text()`.
+	switch in.Val().Kind() {
+	case constant.String:
+		constval = constant.StringVal(in.Val())
+	default:
+		constval = in.Val().String()
+	}
+
+	out.ConstValue = &constval
 	return out
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -341,6 +341,13 @@ type Type struct {
 	// If Kind == func, this is the signature of the function.
 	Signature *Signature
 
+	// ConstValue contains a stringified constant value if
+	// Kind == DeclarationOf and this is a constant value
+	// declaration. For string constants, this field contains
+	// the entire, un-quoted value. For other types, it contains
+	// a human-readable literal.
+	ConstValue *string
+
 	// TODO: Add:
 	// * channel direction
 	// * array length


### PR DESCRIPTION
Capture the value of constants declarations in `parse.Type`. This allows
client code to inspect the values of all constants in a package using
the package's `.Constants` map.

This fixes #187.