### PR TITLE
Preallocate set to the length of the passed elements

### DIFF
--- a/examples/set-gen/generators/sets.go
+++ b/examples/set-gen/generators/sets.go
@@ -187,7 +187,7 @@ type $.type|public$ map[$.type|raw$]Empty
 
 // New$.type|public$ creates a $.type|public$ from a list of values.
 func New$.type|public$(items ...$.type|raw$) $.type|public$ {
-	ss := $.type|public${}
+	ss := make($.type|public$, len(items))
 	ss.Insert(items...)
 	return ss
 }

--- a/examples/set-gen/sets/byte.go
+++ b/examples/set-gen/sets/byte.go
@@ -28,7 +28,7 @@ type Byte map[byte]Empty
 
 // NewByte creates a Byte from a list of values.
 func NewByte(items ...byte) Byte {
-	ss := Byte{}
+	ss := make(Byte, len(items))
 	ss.Insert(items...)
 	return ss
 }

--- a/examples/set-gen/sets/int.go
+++ b/examples/set-gen/sets/int.go
@@ -28,7 +28,7 @@ type Int map[int]Empty
 
 // NewInt creates a Int from a list of values.
 func NewInt(items ...int) Int {
-	ss := Int{}
+	ss := make(Int, len(items))
 	ss.Insert(items...)
 	return ss
 }

--- a/examples/set-gen/sets/int64.go
+++ b/examples/set-gen/sets/int64.go
@@ -28,7 +28,7 @@ type Int64 map[int64]Empty
 
 // NewInt64 creates a Int64 from a list of values.
 func NewInt64(items ...int64) Int64 {
-	ss := Int64{}
+	ss := make(Int64, len(items))
 	ss.Insert(items...)
 	return ss
 }

--- a/examples/set-gen/sets/string.go
+++ b/examples/set-gen/sets/string.go
@@ -28,7 +28,7 @@ type String map[string]Empty
 
 // NewString creates a String from a list of values.
 func NewString(items ...string) String {
-	ss := String{}
+	ss := make(String, len(items))
 	ss.Insert(items...)
 	return ss
 }


### PR DESCRIPTION
When passing a list via the constructor, we usually preallocate "manually" in downstream projects to keep things small'ish.

I do realize that this might be actually worse for lists that are passed for deduplication and where a massive amount of duplicates are present. If we think that's an important case, we could alternative add a new constructor for this behavior or keep doing what we're doing downstream.