### PR TITLE
Add comments to additional types.

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -493,6 +493,19 @@ func (b *Builder) FindTypes() (types.Universe, error) {
 	return u, nil
 }
 
+// addCommentsToType takes any accumulated comment lines prior to obj and
+// attaches them to the type t.
+func (b *Builder) addCommentsToType(obj tc.Object, t *types.Type) {
+	c1 := b.priorCommentLines(obj.Pos(), 1)
+	// c1.Text() is safe if c1 is nil
+	t.CommentLines = splitLines(c1.Text())
+	if c1 == nil {
+		t.SecondClosestCommentLines = splitLines(b.priorCommentLines(obj.Pos(), 2).Text())
+	} else {
+		t.SecondClosestCommentLines = splitLines(b.priorCommentLines(c1.List[0].Slash, 2).Text())
+	}
+}
+
 // findTypesIn finalizes the package import and searches through the package
 // for types.
 func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error {
@@ -536,35 +549,23 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 		tn, ok := obj.(*tc.TypeName)
 		if ok {
 			t := b.walkType(*u, nil, tn.Type())
-			c1 := b.priorCommentLines(obj.Pos(), 1)
-			// c1.Text() is safe if c1 is nil
-			t.CommentLines = splitLines(c1.Text())
-			if c1 == nil {
-				t.SecondClosestCommentLines = splitLines(b.priorCommentLines(obj.Pos(), 2).Text())
-			} else {
-				t.SecondClosestCommentLines = splitLines(b.priorCommentLines(c1.List[0].Slash, 2).Text())
-			}
+			b.addCommentsToType(obj, t)
 		}
 		tf, ok := obj.(*tc.Func)
 		// We only care about functions, not concrete/abstract methods.
 		if ok && tf.Type() != nil && tf.Type().(*tc.Signature).Recv() == nil {
 			t := b.addFunction(*u, nil, tf)
-			c1 := b.priorCommentLines(obj.Pos(), 1)
-			// c1.Text() is safe if c1 is nil
-			t.CommentLines = splitLines(c1.Text())
-			if c1 == nil {
-				t.SecondClosestCommentLines = splitLines(b.priorCommentLines(obj.Pos(), 2).Text())
-			} else {
-				t.SecondClosestCommentLines = splitLines(b.priorCommentLines(c1.List[0].Slash, 2).Text())
-			}
+			b.addCommentsToType(obj, t)
 		}
 		tv, ok := obj.(*tc.Var)
 		if ok && !tv.IsField() {
-			b.addVariable(*u, nil, tv)
+			t := b.addVariable(*u, nil, tv)
+			b.addCommentsToType(obj, t)
 		}
 		tconst, ok := obj.(*tc.Const)
 		if ok {
-			b.addConstant(*u, nil, tconst)
+			t := b.addConstant(*u, nil, tconst)
+			b.addCommentsToType(obj, t)
 		}
 	}
 


### PR DESCRIPTION
Always add comments when we collect a type, so that the caller
gets the choice of whether to consume the comment or not.

This fixes #186.