### PR TITLE
Adjust log level for uncopyable types

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -173,18 +173,24 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		pkgNeedsGeneration := (ptagValue == tagValuePackage)
 		if !pkgNeedsGeneration {
 			// If the pkg-scoped tag did not exist, scan all types for one that
-			// explicitly wants generation.
+			// explicitly wants generation. Ensure all types that want generation
+			// can be copied.
+			var uncopyable []string
 			for _, t := range pkg.Types {
 				klog.V(5).Infof("  considering type %q", t.Name.String())
 				ttag := extractEnabledTypeTag(t)
 				if ttag != nil && ttag.value == "true" {
 					klog.V(5).Infof("    tag=true")
 					if !copyableType(t) {
-						klog.Fatalf("Type %v requests deepcopy generation but is not copyable", t)
+						uncopyable = append(uncopyable, fmt.Sprintf("%v", t))
+					} else {
+						pkgNeedsGeneration = true
 					}
-					pkgNeedsGeneration = true
-					break
 				}
+			}
+			if len(uncopyable) > 0 {
+				klog.Fatalf("Types requested deepcopy generation but are not not copyable: %s",
+					strings.Join(uncopyable, ", "))
 			}
 		}
 
@@ -265,10 +271,6 @@ func (g *genDeepCopy) Filter(c *generator.Context, t *types.Type) bool {
 		}
 	}
 	if !enabled {
-		return false
-	}
-	if !copyableType(t) {
-		klog.V(2).Infof("Type %v is not copyable", t)
 		return false
 	}
 	klog.V(4).Infof("Type %v is copyable", t)

--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -189,7 +189,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				}
 			}
 			if len(uncopyable) > 0 {
-				klog.Fatalf("Types requested deepcopy generation but are not not copyable: %s",
+				klog.Fatalf("Types requested deepcopy generation but are not copyable: %s",
 					strings.Join(uncopyable, ", "))
 			}
 		}


### PR DESCRIPTION
Adjust the log level used when deepcopy-gen encounters a type that requests code generation, but does not support it. Both logs for this condition are now Info V1.

deepcopy-gen performs a check for types that request deepcopy-gen but do not support it in several locations:
- When [checking to see if a package requires code generation at all](https://github.com/kubernetes/gengo/blob/de9496dff47bef4ff8f45a56096bf50798cba2a5/examples/deepcopy-gen/generators/deepcopy.go#L177-L186). This currently logs a fatal error if it encounters an invalid request.
- When [checking to see which individual types in a package need code generation](https://github.com/kubernetes/gengo/blob/de9496dff47bef4ff8f45a56096bf50798cba2a5/examples/deepcopy-gen/generators/deepcopy.go#L270-L273). This currently logs at Info V2 and skips over the type (it treats the type as if it was not marked for deepcopy generation): `I0423 10:08:10.379180 3412441 deepcopy.go:271] Type package/foo.bar is not copyable`

The package-level check effectively chooses a single type from the package at random: the range order is not guaranteed, and it may find a type that requests generation and _is_ copyable first, in which case it will proceed generating code for the package. If there are many copyable types and a few uncopyable types, deepcopy-gen will usually succeed (but not generate any code for the uncopyable types) but sometimes fail, which is a rather confusing UX.

Logging at V1 seems appropriate here seems appropriate. Users should be aware if they've made an impossible request (so that they can either make the type copyable or explicitly disable code generation for it). Since the invalid configuration is handled gracefully (those types are skipped), the package-level check should continue searching for other copyable types in the package rather than failing abruptly.