### PR TITLE
Check for empty strings in addDir/addPackage

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -18,6 +18,7 @@ package generator
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"k8s.io/gengo/namer"
@@ -241,6 +242,9 @@ func (ctxt *Context) TransitiveIncomingImports() map[string][]string {
 // (`which go`) will all be searched, in the normal Go fashion.
 // Deprecated. Please use AddDirectory.
 func (ctxt *Context) AddDir(path string) error {
+	if len(path) == 0 {
+		return fmt.Errorf("Can not add a empty package")
+	}
 	ctxt.incomingImports = nil
 	ctxt.incomingTransitiveImports = nil
 	return ctxt.builder.AddDirTo(path, &ctxt.Universe)
@@ -250,6 +254,9 @@ func (ctxt *Context) AddDir(path string) error {
 // single go package import path.  GOPATH, GOROOT, and the location of your go
 // binary (`which go`) will all be searched, in the normal Go fashion.
 func (ctxt *Context) AddDirectory(path string) (*types.Package, error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("Can not add a empty directory")
+	}
 	ctxt.incomingImports = nil
 	ctxt.incomingTransitiveImports = nil
 	return ctxt.builder.AddDirectoryTo(path, &ctxt.Universe)

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -280,6 +280,10 @@ func (b *Builder) AddDirTo(dir string, u *types.Universe) error {
 func (b *Builder) AddDirectoryTo(dir string, u *types.Universe) (*types.Package, error) {
 	// We want all types from this package, as if they were directly added
 	// by the user.  They WERE added by the user, in effect.
+	if len(dir) == 0 {
+		return nil, fmt.Errorf("Can not add a empty directory")
+	}
+
 	if _, err := b.importPackage(dir, true); err != nil {
 		return nil, err
 	}
@@ -293,6 +297,9 @@ func (b *Builder) AddDirectoryTo(dir string, u *types.Universe) (*types.Package,
 // The implementation of AddDir. A flag indicates whether this directory was
 // user-requested or just from following the import graph.
 func (b *Builder) addDir(dir string, userRequested bool) error {
+	if len(dir) == 0 {
+		return fmt.Errorf("Can not add a empty directory")
+	}
 	klog.V(5).Infof("addDir %s", dir)
 	buildPkg, err := b.importBuildPackage(dir)
 	if err != nil {


### PR DESCRIPTION
When a empty directory is added, the generator will segfault.
Check for empty string arguments.

```
k8s.io/gengo/parser.(*Builder).AddDirTo(0xc00007f630, 0xc000030120, 0x0, 0xc00901e708, 0xc008d406f8, 0x0)
        /home/poelzi/23t/gardener-extension-provider-hcloud/vendor/k8s.io/gengo/parser/parse.go:272 +0xa5
k8s.io/gengo/generator.(*Context).AddDir(...)
        /home/poelzi/23t/gardener-extension-provider-hcloud/vendor/k8s.io/gengo/generator/generator.go:246
k8s.io/code-generator/cmd/conversion-gen/generators.Packages(0xc00901e700, 0xc00011ef00, 0x76e8bc, 0x6, 0xc00901e700)
        /home/poelzi/23t/gardener-extension-provider-hcloud/vendor/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go:307 +0x1199
k8s.io/gengo/args.(*GeneratorArgs).Execute(0xc00011ef00, 0xc000109050, 0x76e8bc, 0x6, 0x79d070, 0xc000052bc0, 0x2)
        /home/poelzi/23t/gardener-extension-provider-hcloud/vendor/k8s.io/gengo/args/args.go:206 +0x1a9
main.main()
        /home/poelzi/23t/gardener-extension-provider-hcloud/vendor/k8s.io/code-generator/cmd/conversion-gen/main.go:129 +0x365

```