### PR TITLE
Add plural_namer test for case of metadata

### DIFF
--- a/namer/plural_namer_test.go
+++ b/namer/plural_namer_test.go
@@ -110,6 +110,11 @@ func TestPluralNamer(t *testing.T) {
 			"leaves",
 			"Leaves",
 		},
+		{
+			"Metadata",
+			"metadatas",
+			"Metadatas",
+		},
 	}
 	for _, c := range cases {
 		testType := &types.Type{Name: types.Name{Name: c.typeName}}


### PR DESCRIPTION
I originally opened an [issue](https://github.com/kubernetes-sigs/controller-tools/issues/578) for kubernetes-sigs/controller-tools regarding the use of Metadata in a CRD name. It seems that controller-tools and client-gen of kubernetes/code-generator differ in the plural interpretation of metadata.

client-gen uses gengo's interpretation that metadatas is the plural form. Whereas controller-tools uses flect.Pluralize from github.com/gobuffalo/flect to use the plural form of metadata.

The intention of this pr is to add a test to verify this behavior moving forward for gengo since metadata, which can be considered both singular and plural, is a bit of an edge case that should be captured somewhere for future reference. 

I would also be interested in using this pr to start a discussion on how to handle this case if there are differing opinions on how to handle this case. 