### PR TITLE
Make defaulter-gen accept package paths as input

### DIFF
--- a/examples/defaulter-gen/generators/defaulter.go
+++ b/examples/defaulter-gen/generators/defaulter.go
@@ -318,9 +318,18 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		}
 		if len(inputTags) == 1 {
 			var err error
-			typesPkg, err = context.AddDirectory(filepath.Join(pkg.Path, inputTags[0]))
+
+			inputPath := inputTags[0]
+			if strings.HasPrefix(inputPath, "./") || strings.HasPrefix(inputPath, "../") {
+				// this is a relative dir, which will not work under gomodules.
+				// join with the local package path, but warn
+				klog.Warningf("relative path %s=%s will not work under gomodule mode; use full package path (as used by 'import') instead", inputTagName, inputPath)
+				inputPath = filepath.Join(pkg.Path, inputTags[0])
+			}
+
+			typesPkg, err = context.AddDirectory(inputPath)
 			if err != nil {
-				klog.Fatalf("cannot import package %s", inputTags[0])
+				klog.Fatalf("cannot import package %s", inputPath)
 			}
 			// update context.Order to the latest context.Universe
 			orderer := namer.Orderer{Namer: namer.NewPublicNamer(1)}


### PR DESCRIPTION
this allows using package import paths, needed to work in module mode

xref https://github.com/kubernetes/kubernetes/issues/82531 and https://github.com/kubernetes/kubernetes/pull/104330

/hold for green CI with this change in k/k

* [x] run with existing defaulter-gen tags: https://github.com/kubernetes/kubernetes/pull/104333
* [x] run with defaulter-gen tags switched to import packages: https://github.com/kubernetes/kubernetes/pull/104330

/assign @sttts