### PR TITLE
make deepcopy-gen compatible with go 1.17

### DIFF
--- a/examples/deepcopy-gen/Makefile
+++ b/examples/deepcopy-gen/Makefile
@@ -7,10 +7,9 @@ test:
 	fi
 	@go build -o /tmp/$(TOOL)
 	@PKGS=$$(go list ./output_tests/...  | paste -sd' ' -); \
-	/tmp/$(TOOL) --logtostderr --v=4 -i $$(echo $$PKGS | sed 's/ /,/g') -O zz_generated
+	/tmp/$(TOOL) --logtostderr --v=4 -i $$(echo $$PKGS | sed 's/ /,/g') -O zz_generated --go-header-file ../../boilerplate/boilerplate.go.txt
 	@if ! git diff --quiet HEAD; then \
 	    echo "FAIL: output files changed"; \
 	    git diff; \
 	    false; \
 	fi
-

--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -133,7 +133,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 	inputs := sets.NewString(context.Inputs...)
 	packages := generator.Packages{}
-	header := append([]byte(fmt.Sprintf("// +build !%s\n\n", arguments.GeneratedBuildTag)), boilerplate...)
+	header := append([]byte(fmt.Sprintf("//go:build !%s\n// +build !%s\n\n", arguments.GeneratedBuildTag, arguments.GeneratedBuildTag)), boilerplate...)
 
 	boundingDirs := []string{}
 	if customArgs, ok := arguments.CustomArgs.(*CustomArgs); ok {


### PR DESCRIPTION
In Golang 1.17, the gofmt tool prefers to use `//go:build` as a build
constraint, https://pkg.go.dev/go/build#hdr-Build_Constraints. So it
seems that the `// +build` was abandoned long ago but the compatibility
was preserved until 1.17.
To ensure compatibility with Golang version older than 1.17 so from 1.16
and below, having both constraints seems to work fine.

Now deepcopy-gen will generate a header like so:

```
//go:build !ignore_autogenerated
// +build !ignore_autogenerated
```

And on Golang 1.17, gofmt will not complain and won't try to append
`go:build` and remove `+build`.

Signed-off-by: Sébastien Han <seb@redhat.com>