### PR TITLE
fix: guard buildPackage access in Builder.AddDirTo

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -530,7 +530,10 @@ func (g *genDeepCopy) deepCopyableInterfacesInner(c *generator.Context, t *types
 	var ts []*types.Type
 	for _, intf := range intfs {
 		t := types.ParseFullyQualifiedName(intf)
-		c.AddDir(t.Package)
+		err := c.AddDir(t.Package)
+		if err != nil {
+			return nil, err
+		}
 		intfT := c.Universe.Type(t)
 		if intfT == nil {
 			return nil, fmt.Errorf("unknown type %q in %s tag of type %s", intf, interfacesTagName, intfT)

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -269,7 +269,11 @@ func (b *Builder) AddDirTo(dir string, u *types.Universe) error {
 	if _, err := b.importPackage(dir, true); err != nil {
 		return err
 	}
-	return b.findTypesIn(canonicalizeImportPath(b.buildPackages[dir].ImportPath), u)
+	pkg, ok := b.buildPackages[dir]
+	if !ok {
+		return fmt.Errorf("no such package: %q", dir)
+	}
+	return b.findTypesIn(canonicalizeImportPath(pkg.ImportPath), u)
 }
 
 // AddDirectoryTo adds an entire directory to a given Universe. Unlike AddDir,
@@ -283,7 +287,11 @@ func (b *Builder) AddDirectoryTo(dir string, u *types.Universe) (*types.Package,
 	if _, err := b.importPackage(dir, true); err != nil {
 		return nil, err
 	}
-	path := canonicalizeImportPath(b.buildPackages[dir].ImportPath)
+	pkg, ok := b.buildPackages[dir]
+	if !ok {
+		return nil, fmt.Errorf("no such package: %q", dir)
+	}
+	path := canonicalizeImportPath(pkg.ImportPath)
 	if err := b.findTypesIn(path, u); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes #211: 
1. Simply checks if the package exists before using it in gengo/parser/parser.go and 
2. propagates the error in gengo/examples/deepcopy-gen/generators/deepcopy.go. that way its displayed to the user