### PR TITLE
Add a Clone function to all sets

### DIFF
--- a/examples/set-gen/generators/sets.go
+++ b/examples/set-gen/generators/sets.go
@@ -246,6 +246,15 @@ func (s $.type|public$) HasAny(items ...$.type|raw$) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s $.type|public$) Clone() $.type|public$ {
+	result := make($.type|public$, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -269,10 +278,7 @@ func (s $.type|public$) Difference(s2 $.type|public$) $.type|public$ {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 $.type|public$) Union(s2 $.type|public$) $.type|public$ {
-	result := New$.type|public$()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/examples/set-gen/sets/byte.go
+++ b/examples/set-gen/sets/byte.go
@@ -87,6 +87,15 @@ func (s Byte) HasAny(items ...byte) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Byte) Clone() Byte {
+	result := make(Byte, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Byte) Difference(s2 Byte) Byte {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Byte) Union(s2 Byte) Byte {
-	result := NewByte()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/examples/set-gen/sets/int.go
+++ b/examples/set-gen/sets/int.go
@@ -87,6 +87,15 @@ func (s Int) HasAny(items ...int) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Int) Clone() Int {
+	result := make(Int, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Int) Difference(s2 Int) Int {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Int) Union(s2 Int) Int {
-	result := NewInt()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/examples/set-gen/sets/int64.go
+++ b/examples/set-gen/sets/int64.go
@@ -87,6 +87,15 @@ func (s Int64) HasAny(items ...int64) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s Int64) Clone() Int64 {
+	result := make(Int64, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s Int64) Difference(s2 Int64) Int64 {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 Int64) Union(s2 Int64) Int64 {
-	result := NewInt64()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}

--- a/examples/set-gen/sets/string.go
+++ b/examples/set-gen/sets/string.go
@@ -87,6 +87,15 @@ func (s String) HasAny(items ...string) bool {
 	return false
 }
 
+// Clone returns a new set which is a copy of the current set.
+func (s String) Clone() String {
+	result := make(String, len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {a1, a2, a3}
@@ -110,10 +119,7 @@ func (s String) Difference(s2 String) String {
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
 func (s1 String) Union(s2 String) String {
-	result := NewString()
-	for key := range s1 {
-		result.Insert(key)
-	}
+	result := s1.Clone()
 	for key := range s2 {
 		result.Insert(key)
 	}


### PR DESCRIPTION
I recently had a case where I needed a straight up copy of a set and the first intuition was doing `NewString(s.List()...)` which has numerous inefficiencies (interim slice + sorting the slice). So slightly better would've been `NewString(s.UnsortedList()...)`, still requiring an interim slice though. The best possible way of doing it (without relying on iterating the set ourselves) is `s.Union(nil)`, where the only remaining problem is that the result set could be preallocated actually.

Soooo, this does just that! Maybe it's useful to others as well.