### PR TITLE
Fixes kubernetes#217

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -639,6 +639,7 @@ func tcNameToName(in string) types.Name {
 		strings.HasPrefix(in, "chan<-") ||
 		strings.HasPrefix(in, "chan ") ||
 		strings.HasPrefix(in, "func(") ||
+		strings.HasPrefix(in, "func (") ||
 		strings.HasPrefix(in, "*") ||
 		strings.HasPrefix(in, "map[") ||
 		strings.HasPrefix(in, "[") {

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -35,13 +35,14 @@ import (
 )
 
 func TestRecursive(t *testing.T) {
+	dir := "k8s.io/gengo/testdata/a"
 	d := args.Default()
-	d.InputDirs = []string{"k8s.io/gengo/testdata/a/..."}
+	d.InputDirs = []string{dir + "/..."}
 	b, err := d.NewBuilder()
 	if err != nil {
 		t.Fatalf("Fail making builder: %v", err)
 	}
-	_, err = b.FindTypes()
+	findTypes, err := b.FindTypes()
 	if err != nil {
 		t.Fatalf("Fail finding types: %v", err)
 	}
@@ -61,6 +62,14 @@ func TestRecursive(t *testing.T) {
 	}
 	if foundC {
 		t.Error("Did not expect to find package c")
+	}
+	if name := findTypes[dir].Types["AA"].Methods["AFunc"].Name.Name;
+		name != "func (*k8s.io/gengo/testdata/a.AA).AFunc(i *int, j int) (*k8s.io/gengo/testdata/a.A, k8s.io/gengo/testdata/a/b.ITest, error)" {
+		t.Errorf("Parse method type error, got name: %s", name)
+	}
+	// only has three package: package "a", package "b", and package "" for all
+	if len(findTypes) != 3 {
+		t.Error("Parse type error, and take type path as package")
 	}
 }
 

--- a/testdata/a/a.go
+++ b/testdata/a/a.go
@@ -16,5 +16,17 @@ limitations under the License.
 
 package a
 
+import "k8s.io/gengo/testdata/a/b"
+
 // A is a type for testing.
 type A string
+
+// AA is a struct type for testing.
+type AA struct {
+	FieldA string
+}
+
+// AFunc is a member function for testing.
+func (a *AA) AFunc(i *int, j int) (*A, b.ITest, error) {
+	return nil, nil, nil
+}

--- a/testdata/a/b/b.go
+++ b/testdata/a/b/b.go
@@ -18,3 +18,8 @@ package b
 
 // B is a type for testing
 type B string
+
+// ITest is an interface for testing.
+type ITest interface {
+	Test()
+}


### PR DESCRIPTION
If name has prefix 'func (', just return types.Name without parsing more. Fixes kubernetes#217