### PR TITLE
Add ParameterName and ResultNames to Signature struct

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -661,9 +661,11 @@ func (b *Builder) convertSignature(u types.Universe, t *tc.Signature) *types.Sig
 	signature := &types.Signature{}
 	for i := 0; i < t.Params().Len(); i++ {
 		signature.Parameters = append(signature.Parameters, b.walkType(u, nil, t.Params().At(i).Type()))
+		signature.ParameterNames = append(signature.ParameterNames, t.Params().At(i).Name())
 	}
 	for i := 0; i < t.Results().Len(); i++ {
 		signature.Results = append(signature.Results, b.walkType(u, nil, t.Results().At(i).Type()))
+		signature.ResultNames = append(signature.ResultNames, t.Results().At(i).Name())
 	}
 	if r := t.Recv(); r != nil {
 		signature.Receiver = b.walkType(u, nil, r.Type())

--- a/types/types.go
+++ b/types/types.go
@@ -423,12 +423,12 @@ func (m Member) String() string {
 
 // Signature is a function's signature.
 type Signature struct {
-	// TODO: store the parameter names, not just types.
-
 	// If a method of some type, this is the type it's a member of.
-	Receiver   *Type
-	Parameters []*Type
-	Results    []*Type
+	Receiver       *Type
+	Parameters     []*Type
+	ParameterNames []string
+	Results        []*Type
+	ResultNames    []string
 
 	// True if the last in parameter is of the form ...T.
 	Variadic bool


### PR DESCRIPTION
Adds a `ParameterName` and `ResultNames` field to the `Signature` struct and populates these fields when parsing. 

Both `ParameterName` and `ResultNames` will be nil if the list of names is empty. Parameters and results with no names will be represented as empty strings.

I opted to add new fields instead of modifying the type of the existing `Parameter/Result` fields because
- `Variadic` already sets precedent for having information about the parameters on the `Signature` struct
- Modifying the type of the publicly exposed fields will make it harder for downstream users to upgrade
