### PR TITLE
Read package comments from groupversion_info.go for kubebuilder

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -568,7 +568,7 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 	u.Package(string(pkgPath)).SourcePath = b.absPaths[pkgPath]
 
 	for _, f := range b.parsed[pkgPath] {
-		if _, fileName := filepath.Split(f.name); fileName == "doc.go" {
+		if _, fileName := filepath.Split(f.name); fileName == "doc.go" || fileName == "groupversion_info.go" {
 			tp := u.Package(string(pkgPath))
 			// findTypesIn might be called multiple times. Clean up tp.Comments
 			// to avoid repeatedly fill same comments to it.


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

Kubebuilder generated api types will have the groupname annotation in the `groupversion_info.go` file. This change ensures that it is possible to run gengo against kubebuilder generated codebase to correctly detect groupName.