### PR TITLE
Restore uncopyable type case in Filter

### DIFF
--- a/examples/deepcopy-gen/generators/deepcopy.go
+++ b/examples/deepcopy-gen/generators/deepcopy.go
@@ -273,6 +273,10 @@ func (g *genDeepCopy) Filter(c *generator.Context, t *types.Type) bool {
 	if !enabled {
 		return false
 	}
+	if !copyableType(t) {
+		klog.V(2).Infof("Type %v is not copyable", t)
+		return false
+	}
 	klog.V(4).Infof("Type %v is copyable", t)
 	g.typesForInit = append(g.typesForInit, t)
 	return true


### PR DESCRIPTION
Restore the false return for uncopyable types in generators.Filter(). This is necessary to avoid feeding non-struct types into the generator. This partially reverts [a change](https://github.com/kubernetes/gengo/pull/199/files#diff-b7ebf0c01247d2b5d81765758541f8bc7f03860ae4727278f49ee89444e5af81L270-L273) from #199 based on @thockin's [reported issue](https://github.com/kubernetes/gengo/pull/199#issuecomment-1251674636).

I don't quite understand the other types that otherwise get sent to the generator without this, but generally it looks like they're all [non-structs](https://gist.github.com/rainest/2d53d7c6924f859a7a40e8053156377a#file-uncopyable-txt). These aren't included in the initial package scan but do attempt deepcopy generation after AFAICT.

This change allows generation to proceed on k/k while [still aggregating all the uncopyable struct types](https://gist.github.com/rainest/2d53d7c6924f859a7a40e8053156377a#file-test-txt) during the initial package scan (it lists all problem types in [my code that prompted the original change](https://github.com/kubernetes/gengo/pull/199#issuecomment-1048319739)).