### PR TITLE
Fix declarative defaults for aliases

### DIFF
--- a/examples/defaulter-gen/_output_tests/marker/external/constant.go
+++ b/examples/defaulter-gen/_output_tests/marker/external/constant.go
@@ -2,3 +2,9 @@ package external
 
 // Used for test with multiple packages of the same name
 const AConstant string = "AConstantString"
+
+type AStringType string
+
+const (
+	Foo AStringType = "Foo"
+)

--- a/examples/defaulter-gen/_output_tests/marker/marker_test.go
+++ b/examples/defaulter-gen/_output_tests/marker/marker_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/gengo/examples/defaulter-gen/_output_tests/marker/external"
 	external1 "k8s.io/gengo/examples/defaulter-gen/_output_tests/marker/external"
 	external2 "k8s.io/gengo/examples/defaulter-gen/_output_tests/marker/external/external"
 )
@@ -29,6 +30,8 @@ func getPointerFromString(s string) *string {
 }
 
 func Test_Marker(t *testing.T) {
+	foo := external.Foo
+
 	testcases := []struct {
 		name string
 		in   Defaulted
@@ -103,6 +106,7 @@ func Test_Marker(t *testing.T) {
 				QualifiedSymbolReference:        "/dev/termination-log",
 				SameNamePackageSymbolReference1: external1.AConstant,
 				SameNamePackageSymbolReference2: external2.AnotherConstant,
+				AliasSymbolReference:            &foo,
 			},
 		},
 		{
@@ -177,6 +181,7 @@ func Test_Marker(t *testing.T) {
 				QualifiedSymbolReference:        "/dev/termination-log",
 				SameNamePackageSymbolReference1: external1.AConstant,
 				SameNamePackageSymbolReference2: external2.AnotherConstant,
+				AliasSymbolReference:            &foo,
 			},
 		},
 		{
@@ -253,6 +258,7 @@ func Test_Marker(t *testing.T) {
 				QualifiedSymbolReference:        "/dev/termination-log",
 				SameNamePackageSymbolReference1: external1.AConstant,
 				SameNamePackageSymbolReference2: external2.AnotherConstant,
+				AliasSymbolReference:            &foo,
 			},
 		},
 		{
@@ -330,6 +336,7 @@ func Test_Marker(t *testing.T) {
 				QualifiedSymbolReference:        "/dev/termination-log",
 				SameNamePackageSymbolReference1: external1.AConstant,
 				SameNamePackageSymbolReference2: external2.AnotherConstant,
+				AliasSymbolReference:            &foo,
 			},
 		},
 	}

--- a/examples/defaulter-gen/_output_tests/marker/type.go
+++ b/examples/defaulter-gen/_output_tests/marker/type.go
@@ -18,6 +18,7 @@ package marker
 
 import (
 	"k8s.io/gengo/examples/defaulter-gen/_output_tests/empty"
+	"k8s.io/gengo/examples/defaulter-gen/_output_tests/marker/external"
 )
 
 type Defaulted struct {
@@ -95,6 +96,9 @@ type Defaulted struct {
 
 	// +default=ref(k8s.io/gengo/examples/defaulter-gen/_output_tests/marker/external/external.AnotherConstant)
 	SameNamePackageSymbolReference2 string
+
+	// +default=ref(k8s.io/gengo/examples/defaulter-gen/_output_tests/marker/external.Foo)
+	AliasSymbolReference *external.AStringType
 }
 
 const SomeDefault = "ACoolConstant"

--- a/examples/defaulter-gen/_output_tests/marker/zz_generated.go
+++ b/examples/defaulter-gen/_output_tests/marker/zz_generated.go
@@ -142,6 +142,10 @@ func SetObjectDefaults_Defaulted(in *Defaulted) {
 	if in.SameNamePackageSymbolReference2 == "" {
 		in.SameNamePackageSymbolReference2 = externalexternal.AnotherConstant
 	}
+	if in.AliasSymbolReference == nil {
+		var ptrVar1 external.AStringType = external.Foo
+		in.AliasSymbolReference = &ptrVar1
+	}
 }
 
 func SetObjectDefaults_DefaultedWithFunction(in *DefaultedWithFunction) {

--- a/generator/import_tracker.go
+++ b/generator/import_tracker.go
@@ -29,7 +29,7 @@ import (
 func NewImportTracker(typesToAdd ...*types.Type) *namer.DefaultImportTracker {
 	tracker := namer.NewDefaultImportTracker(types.Name{})
 	tracker.IsInvalidType = func(*types.Type) bool { return false }
-	tracker.LocalName = func(name types.Name) string { return golangTrackerLocalName(&tracker, name) }
+	tracker.LocalName = func(name types.Name) string { return GolangTrackerLocalName(&tracker, name) }
 	tracker.PrintImport = func(path, name string) string { return name + " \"" + path + "\"" }
 
 	tracker.AddTypes(typesToAdd...)
@@ -37,7 +37,7 @@ func NewImportTracker(typesToAdd ...*types.Type) *namer.DefaultImportTracker {
 
 }
 
-func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
+func GolangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 	path := t.Package
 
 	// Using backslashes in package names causes gengo to produce Go code which


### PR DESCRIPTION
Fixes https://github.com/kubernetes/gengo/issues/235
For https://github.com/kubernetes/kubernetes/issues/104207

This commit ensures that the alias types are not unpacked to the underlying type in defaulter-gen. Instead the alias type name is carried into the generated code.

For the example described in #235:

Adding the declarative default as:

```go
// +default=ref(k8s.io/api/core/v1.ServiceInternalTrafficPolicyCluster)
InternalTrafficPolicy *ServiceInternalTrafficPolicy `json:"internalTrafficPolicy,omitempty" protobuf:"bytes,22,opt,name=internalTrafficPolicy"`
```

would generate code like:

```go
if in.Spec.InternalTrafficPolicy == nil {
  var ptrVar1 v1.ServiceInternalTrafficPolicy = v1.ServiceInternalTrafficPolicyCluster
  in.Spec.InternalTrafficPolicy = &ptrVar1
}
```

/cc @apelisse @thockin 
/assign @apelisse 
