### PR TITLE
Normalize generator name in comment between Windows and Linux/Unix

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -121,7 +120,7 @@ func (g *GeneratorArgs) LoadGoBoilerplate() ([]byte, error) {
 		if len(b) != 0 {
 			b = append(b, byte('\n'))
 		}
-		generatorName := path.Base(os.Args[0])
+		generatorName := filepath.Base(os.Args[0])
 		generatedByComment := strings.Replace(g.GeneratedByCommentTemplate, "GENERATOR_NAME", generatorName, -1)
 		s := fmt.Sprintf("%s\n\n", generatedByComment)
 		b = append(b, []byte(s)...)

--- a/args/args.go
+++ b/args/args.go
@@ -121,6 +121,8 @@ func (g *GeneratorArgs) LoadGoBoilerplate() ([]byte, error) {
 			b = append(b, byte('\n'))
 		}
 		generatorName := filepath.Base(os.Args[0])
+		// Strip the extension from the name to normalize output between *nix and Windows.
+		generatorName = generatorName[:len(generatorName)-len(filepath.Ext(generatorName))]
 		generatedByComment := strings.Replace(g.GeneratedByCommentTemplate, "GENERATOR_NAME", generatorName, -1)
 		s := fmt.Sprintf("%s\n\n", generatedByComment)
 		b = append(b, []byte(s)...)


### PR DESCRIPTION
The generatorName value was using path.Base instead of filepath.Base, resulting in the full path to the generator being added to the `// Code generated by ...` comment on Windows. This PR switches that to use filepath.Base. Additionally, the generators on Windows have .exe extensions, which would otherwise get included in the comment. To normalize the output between Windows and Linux/Unix, I'm stripping the extension (if present) from the generator name.

The main goal of all this is to ensure that a generator run on Windows doesn't produce different output than running the same generator on Linux/Unix.

This should resolve #242.