### PR TITLE
Avoid check imports for forbidden if already allowed

### DIFF
--- a/examples/import-boss/generators/import_restrict.go
+++ b/examples/import-boss/generators/import_restrict.go
@@ -281,17 +281,21 @@ func (irf importRuleFile) verifyRules(restrictionFiles []*fileFormat, f *generat
 				if !matching {
 					continue
 				}
-				for _, forbidden := range r.ForbiddenPrefixes {
-					klog.V(4).Infof("Checking %v against %v\n", v, forbidden)
-					if strings.HasPrefix(v, forbidden) {
-						forbiddenImports[v] = forbidden
-					}
-				}
+				importInAllowList := false
 				for _, allowed := range r.AllowedPrefixes {
 					klog.V(4).Infof("Checking %v against %v\n", v, allowed)
 					if strings.HasPrefix(v, allowed) {
 						explicitlyAllowed = true
+						importInAllowList = true
 						break
+					}
+				}
+				if !importInAllowList {
+					for _, forbidden := range r.ForbiddenPrefixes {
+						klog.V(4).Infof("Checking %v against %v\n", v, forbidden)
+						if strings.HasPrefix(v, forbidden) {
+							forbiddenImports[v] = forbidden
+						}
 					}
 				}
 


### PR DESCRIPTION
Take the following example, even if `github.com/opencontainers/runc/libcontainer/capabilities` was in `allowedPrefixes`, it still matches `forbiddenPrefixes` and hence fails the verify test. I would like to make sure that i can list all the imports i explicitly allow and forbid anything else that are not in the allow list. I can't explicitly list `forbiddenPrefixes` because that list may change when newer versions of runc are picked up and it is easier to grep or look in vendors for what we explicitly allow/use.

```
rules:
  # stop unnecessary usage of runc vendored code in kubelet
  - selectorRegexp: "github[.]com/opencontainers/runc"
    allowedPrefixes:
      - "github.com/opencontainers/runc/libcontainer/capabilities"
      - "github.com/opencontainers/runc/libcontainer/apparmor"
      - "github.com/opencontainers/runc/libcontainer/utils"
      - "github.com/opencontainers/runc/libcontainer/user"
      - "github.com/opencontainers/runc/libcontainer/devices"
    forbiddenPrefixes:
      - ""
```