### PR TITLE
Support parsing type parameters

### DIFF
--- a/v2/parser/parse.go
+++ b/v2/parser/parse.go
@@ -587,9 +587,16 @@ func goNameToName(in string) types.Name {
 		return types.Name{Name: in}
 	}
 
+	// There may be '.' characters within a generic. Temporarily remove
+	// the generic.
+	genericIndex := strings.IndexRune(in, '[')
+	if genericIndex == -1 {
+		genericIndex = len(in)
+	}
+
 	// Otherwise, if there are '.' characters present, the name has a
 	// package path in front.
-	nameParts := strings.Split(in, ".")
+	nameParts := strings.Split(in[:genericIndex], ".")
 	name := types.Name{Name: in}
 	if n := len(nameParts); n >= 2 {
 		// The final "." is the name of the type--previous ones must
@@ -738,6 +745,27 @@ func (p *Parser) walkType(u types.Universe, useName *types.Name, in gotypes.Type
 			}
 			out.Kind = types.Alias
 			out.Underlying = p.walkType(u, nil, t.Underlying())
+		case *gotypes.Struct:
+			name := goNameToName(t.String())
+			tpMap := map[string]*types.Type{}
+			if t.TypeParams().Len() != 0 {
+				// Remove generics, then readd them without the encoded
+				// type, e.g. Foo[T any] => Foo[T]
+				var tpNames []string
+				for i := 0; i < t.TypeParams().Len(); i++ {
+					tp := t.TypeParams().At(i)
+					tpName := tp.Obj().Name()
+					tpNames = append(tpNames, tpName)
+					tpMap[tpName] = p.walkType(u, nil, tp.Constraint())
+				}
+				name.Name = fmt.Sprintf("%s[%s]", strings.SplitN(name.Name, "[", 2)[0], strings.Join(tpNames, ","))
+			}
+
+			if out := u.Type(name); out.Kind != types.Unknown {
+				return out // short circuit if we've already made this.
+			}
+			out = p.walkType(u, &name, t.Underlying())
+			out.TypeParams = tpMap
 		default:
 			// gotypes package makes everything "named" with an
 			// underlying anonymous type--we remove that annoying
@@ -764,6 +792,15 @@ func (p *Parser) walkType(u types.Universe, useName *types.Name, in gotypes.Type
 			}
 		}
 		return out
+	case *gotypes.TypeParam:
+		// DO NOT retrieve the type from the universe. The default type-param name is only the
+		// generic variable name. Ideally, it would be namespaced by package and struct but it is
+		// not. Thus, if we try to use the universe, we would start polluting it.
+		// e.g. if Foo[T] and Bar[T] exists, we'd mistakenly use the same type T for both.
+		return &types.Type{
+			Name: name,
+			Kind: types.TypeParam,
+		}
 	default:
 		out := u.Type(name)
 		if out.Kind != types.Unknown {

--- a/v2/parser/testdata/basic/file.go
+++ b/v2/parser/testdata/basic/file.go
@@ -1,0 +1,12 @@
+package foo
+
+// Blah is a test.
+// A test, I tell you.
+type Blah struct {
+	// A is the first field.
+	A int64 `json:"a"`
+
+	// B is the second field.
+	// Multiline comments work.
+	B string `json:"b"`
+}

--- a/v2/parser/testdata/generic-multi/file.go
+++ b/v2/parser/testdata/generic-multi/file.go
@@ -1,0 +1,10 @@
+package foo
+
+type Blah[T any, U any, V any] struct {
+	// V1 is the first field.
+	V1 T `json:"v1"`
+	// V2 is the second field.
+	V2 U `json:"v2"`
+	// V3 is the third field.
+	V3 V `json:"v3"`
+}

--- a/v2/parser/testdata/generic-recursive/file.go
+++ b/v2/parser/testdata/generic-recursive/file.go
@@ -1,0 +1,10 @@
+package foo
+
+type DeepCopyable[T any] interface {
+	DeepCopy() T
+}
+
+type Blah[T DeepCopyable[T]] struct {
+	// V is the first field.
+	V T `json:"v"`
+}

--- a/v2/parser/testdata/generic/file.go
+++ b/v2/parser/testdata/generic/file.go
@@ -1,0 +1,6 @@
+package foo
+
+type Blah[T any] struct {
+	// V is the first field.
+	V T `json:"v"`
+}

--- a/v2/types/types.go
+++ b/v2/types/types.go
@@ -98,6 +98,7 @@ const (
 	DeclarationOf Kind = "DeclarationOf"
 	Unknown       Kind = ""
 	Unsupported   Kind = "Unsupported"
+	TypeParam     Kind = "TypeParam"
 
 	// Protobuf is protobuf type.
 	Protobuf Kind = "Protobuf"
@@ -323,6 +324,9 @@ type Type struct {
 
 	// If Kind == Struct
 	Members []Member
+
+	// If Kind == Struct
+	TypeParams map[string]*Type
 
 	// If Kind == Map, Slice, Pointer, or Chan
 	Elem *Type


### PR DESCRIPTION
This PR allows the parser to parse generics (partial fix for #225).

However, this PR **does not** allow generators to take advantage of it. For example, the deepcopy generator will still fail if you use a generic field, because it does not know whether that generic has a `DeepCopy` method. Although, the deepcopy generator will now work when you use a phantom type, which was not possible before. What are the use-cases for a phantom type? No clue, but I figured splitting the fix for #225 into multiple PRs would be easier to get reviewed and merged.