### PR TITLE
Support parsing directives in comment of methods, structs, struct members and package doc

### DIFF
--- a/third_party/forked/golang/LICENSE
+++ b/third_party/forked/golang/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/forked/golang/PATENTS
+++ b/third_party/forked/golang/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/third_party/forked/golang/go/ast/ast.go
+++ b/third_party/forked/golang/go/ast/ast.go
@@ -1,0 +1,41 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This package is copied from Go library net.
+// https://golang.org/src/go/ast/ast.go
+// The original private function isDirective
+// is exported as public function.
+
+package ast
+
+import "strings"
+
+// IsDirective reports whether c is a comment directive.
+// This code is also in go/printer.
+func IsDirective(c string) bool {
+	// "//line " is a line directive.
+	// "//extern " is for gccgo.
+	// "//export " is for cgo.
+	// (The // has been removed.)
+	if strings.HasPrefix(c, "line ") || strings.HasPrefix(c, "extern ") || strings.HasPrefix(c, "export ") {
+		return true
+	}
+
+	// "//[a-z0-9]+:[a-z0-9]"
+	// (The // has been removed.)
+	colon := strings.Index(c, ":")
+	if colon <= 0 || colon+1 >= len(c) {
+		return false
+	}
+	for i := 0; i <= colon+1; i++ {
+		if i == colon {
+			continue
+		}
+		b := c[i]
+		if !('a' <= b && b <= 'z' || '0' <= b && b <= '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/third_party/forked/golang/go/ast/ast_test.go
+++ b/third_party/forked/golang/go/ast/ast_test.go
@@ -1,0 +1,41 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This package is copied from Go library net.
+// https://golang.org/src/go/ast/ast.go
+// The original private function isDirective
+// is exported as public function.
+
+package ast
+
+import "testing"
+
+var isDirectiveTests = []struct {
+	in string
+	ok bool
+}{
+	{"abc", false},
+	{"go:inline", true},
+	{"Go:inline", false},
+	{"go:Inline", false},
+	{":inline", false},
+	{"lint:ignore", true},
+	{"lint:1234", true},
+	{"1234:lint", true},
+	{"go: inline", false},
+	{"go:", false},
+	{"go:*", false},
+	{"go:x*", true},
+	{"export foo", true},
+	{"extern foo", true},
+	{"expert foo", false},
+}
+
+func TestIsDirective(t *testing.T) {
+	for _, tt := range isDirectiveTests {
+		if ok := IsDirective(tt.in); ok != tt.ok {
+			t.Errorf("isDirective(%q) = %v, want %v", tt.in, ok, tt.ok)
+		}
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -125,6 +125,9 @@ type Package struct {
 	// TODO: remove Comments and use DocComments everywhere.
 	Comments []string
 
+	// The directives right above the package declaration in doc.go, if any.
+	DocDirectives []string
+
 	// Types within this package, indexed by their name (*not* including
 	// package name).
 	Types map[string]*Type
@@ -322,6 +325,10 @@ type Type struct {
 	// ---
 	SecondClosestCommentLines []string
 
+	// If there are directives immediately before the type definition,
+	// they will be recorded here.
+	Directives []string
+
 	// If Kind == Struct
 	Members []Member
 
@@ -408,6 +415,10 @@ type Member struct {
 	// If there are comment lines immediately before the member in the type
 	// definition, they will be recorded here.
 	CommentLines []string
+
+	// If there are directives immediately before the type definition,
+	// they will be recorded here.
+	Directives []string
 
 	// If there are tags along with this member, they will be saved here.
 	Tags string


### PR DESCRIPTION
This PR add support for parsing directives in comment of methods, structs, and struct members