### PR TITLE
v2: Replace parallel arrays with array of objects

### DIFF
--- a/v2/namer/namer.go
+++ b/v2/namer/namer.go
@@ -281,12 +281,12 @@ func (ns *NameStrategy) Name(t *types.Type) string {
 	case types.Func:
 		// TODO: add to name test
 		parts := []string{"Func"}
-		for _, pt := range t.Signature.Parameters {
-			parts = append(parts, ns.removePrefixAndSuffix(ns.Name(pt)))
+		for _, param := range t.Signature.Parameters {
+			parts = append(parts, ns.removePrefixAndSuffix(ns.Name(param.Type)))
 		}
 		parts = append(parts, "Returns")
-		for _, rt := range t.Signature.Results {
-			parts = append(parts, ns.removePrefixAndSuffix(ns.Name(rt)))
+		for _, result := range t.Signature.Results {
+			parts = append(parts, ns.removePrefixAndSuffix(ns.Name(result.Type)))
 		}
 		name = ns.Join(ns.Prefix, parts, ns.Suffix)
 	default:
@@ -374,12 +374,12 @@ func (r *rawNamer) Name(t *types.Type) string {
 	case types.Func:
 		// TODO: add to name test
 		params := []string{}
-		for _, pt := range t.Signature.Parameters {
-			params = append(params, r.Name(pt))
+		for _, param := range t.Signature.Parameters {
+			params = append(params, r.Name(param.Type))
 		}
 		results := []string{}
-		for _, rt := range t.Signature.Results {
-			results = append(results, r.Name(rt))
+		for _, result := range t.Signature.Results {
+			results = append(results, r.Name(result.Type))
 		}
 		name = "func(" + strings.Join(params, ",") + ")"
 		if len(results) == 1 {

--- a/v2/parser/parse.go
+++ b/v2/parser/parse.go
@@ -602,12 +602,16 @@ func goNameToName(in string) types.Name {
 func (p *Parser) convertSignature(u types.Universe, t *gotypes.Signature) *types.Signature {
 	signature := &types.Signature{}
 	for i := 0; i < t.Params().Len(); i++ {
-		signature.Parameters = append(signature.Parameters, p.walkType(u, nil, t.Params().At(i).Type()))
-		signature.ParameterNames = append(signature.ParameterNames, t.Params().At(i).Name())
+		signature.Parameters = append(signature.Parameters, &types.ParamResult{
+			Name: t.Params().At(i).Name(),
+			Type: p.walkType(u, nil, t.Params().At(i).Type()),
+		})
 	}
 	for i := 0; i < t.Results().Len(); i++ {
-		signature.Results = append(signature.Results, p.walkType(u, nil, t.Results().At(i).Type()))
-		signature.ResultNames = append(signature.ResultNames, t.Results().At(i).Name())
+		signature.Results = append(signature.Results, &types.ParamResult{
+			Name: t.Results().At(i).Name(),
+			Type: p.walkType(u, nil, t.Results().At(i).Type()),
+		})
 	}
 	if r := t.Recv(); r != nil {
 		signature.Receiver = p.walkType(u, nil, r.Type())

--- a/v2/types/types.go
+++ b/v2/types/types.go
@@ -423,14 +423,20 @@ func (m Member) String() string {
 	return m.Name + " " + m.Type.String()
 }
 
+// ParamResult represents a parameter or a result of a method's signature.
+type ParamResult struct {
+	// The name of the parameter or result.
+	Name string
+	// The type of this parameter or result.
+	Type *Type
+}
+
 // Signature is a function's signature.
 type Signature struct {
 	// If a method of some type, this is the type it's a member of.
-	Receiver       *Type
-	Parameters     []*Type
-	ParameterNames []string
-	Results        []*Type
-	ResultNames    []string
+	Receiver   *Type
+	Parameters []*ParamResult
+	Results    []*ParamResult
 
 	// True if the last in parameter is of the form ...T.
 	Variadic bool


### PR DESCRIPTION
This PR replaces parallel arrays with array of objects in `Results` and `Parameters` of `Signature` for improved code readability and maintainability.