### PR TITLE
Handle empty package name from import tracker while naming a type.

### DIFF
--- a/v2/namer/namer.go
+++ b/v2/namer/namer.go
@@ -329,7 +329,12 @@ func (r *rawNamer) Name(t *types.Type) string {
 			if t.Name.Package == r.pkg {
 				name = t.Name.Name
 			} else {
-				name = r.tracker.LocalNameOf(t.Name.Package) + "." + t.Name.Name
+				packageName := r.tracker.LocalNameOf(t.Name.Package)
+				if packageName == "" {
+					name = t.Name.Name
+				} else {
+					name = packageName + "." + t.Name.Name
+				}
 			}
 		} else {
 			if t.Name.Package == r.pkg {

--- a/v2/namer/namer_test.go
+++ b/v2/namer/namer_test.go
@@ -103,3 +103,32 @@ func TestNameStrategy(t *testing.T) {
 		t.Errorf("Wanted %#v, got %#v", e, a)
 	}
 }
+
+// NOTE: this test is intended to demostrate specific behavior
+// described in https://github.com/kubernetes/kubernetes/issues/124192
+// and should not be considered a good usage scenario of Namer
+//
+// Here we are trying to simulate the behavior when Namer is
+// configured with invalid local package name and import tracker
+// has valid configuration. In this case Namer shouldn't produce
+// invalid syntax like '.<variableName>' and instead treat empty
+// names from import tracker as types within the same package
+func TestRawNamerEmptyImportInteraction(t *testing.T) {
+	tracker := NewDefaultImportTracker(types.Name{
+		Package: "resource.io/pkg",
+		Name:    "name",
+	})
+	namer := NewRawNamer("resource/pkg", &tracker)
+
+	gotName := namer.Name(&types.Type{
+		Name: types.Name{
+			Package: "resource.io/pkg",
+			Name:    "flag",
+			Path:    "/path/resource.io/pkg",
+		},
+	})
+
+	if gotName != "flag" {
+		t.Errorf("Wanted %#v, got %#v", "flag", gotName)
+	}
+}


### PR DESCRIPTION
This commit adds handling for empty package namer while generating a type name, effectively treating such types as local ones.  Right now the behavior would generate an invalid syntax in such scenario

Probably related to https://github.com/kubernetes/gengo/issues/266

This PR is needed in the context of https://github.com/kubernetes/kubernetes/pull/124190 so that we are able to mitigate the problem with invalid package name supplied into namer without largely impacting other usage scenarios.

xref https://github.com/kubernetes/kubernetes/issues/124192

/assign jpbetz 