### PR TITLE
Fix deepcopy for generics

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -10,5 +10,6 @@ require (
 
 require (
 	github.com/go-logr/logr v0.2.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,5 +1,7 @@
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=

--- a/v2/parser/parse.go
+++ b/v2/parser/parse.go
@@ -572,6 +572,9 @@ func goVarNameToName(in string) types.Name {
 	return goNameToName(nameParts[1])
 }
 
+// goNameToName converts a go name string to a gengo types.Name.
+// It operates solely on the string on a best effort basis. The name may be updated
+// in walkType for generics.
 func goNameToName(in string) types.Name {
 	// Detect anonymous type names. (These may have '.' characters because
 	// embedded types may have packages, so we detect them specially.)
@@ -602,6 +605,10 @@ func goNameToName(in string) types.Name {
 		// The final "." is the name of the type--previous ones must
 		// have been in the package path.
 		name.Package, name.Name = strings.Join(nameParts[:n-1], "."), nameParts[n-1]
+		// Add back the generic component now that the package and type name have been separated.
+		if genericIndex != len(in) {
+			name.Name = name.Name + in[genericIndex:]
+		}
 	}
 	return name
 }

--- a/v2/parser/parse.go
+++ b/v2/parser/parse.go
@@ -752,7 +752,7 @@ func (p *Parser) walkType(u types.Universe, useName *types.Name, in gotypes.Type
 			}
 			out.Kind = types.Alias
 			out.Underlying = p.walkType(u, nil, t.Underlying())
-		case *gotypes.Struct:
+		case *gotypes.Struct, *gotypes.Interface:
 			name := goNameToName(t.String())
 			tpMap := map[string]*types.Type{}
 			if t.TypeParams().Len() != 0 {

--- a/v2/parser/parse_test.go
+++ b/v2/parser/parse_test.go
@@ -894,6 +894,62 @@ func TestStructParse(t *testing.T) {
 			},
 		},
 		{
+			description: "generic on field",
+			testFile:    "./testdata/generic-field",
+			expected: func() *types.Type {
+				fieldType := &types.Type{
+					Name: types.Name{
+						Package: "k8s.io/gengo/v2/parser/testdata/generic-field",
+						Name:    "Blah[T]",
+					},
+					Kind:                      types.Struct,
+					CommentLines:              []string{""},
+					SecondClosestCommentLines: []string{""},
+					Members: []types.Member{
+						{
+							Name:         "V",
+							Embedded:     false,
+							CommentLines: []string{"V is the first field."},
+							Tags:         `json:"v"`,
+							Type: &types.Type{
+								Kind: types.TypeParam,
+								Name: types.Name{
+									Name: "T",
+								},
+							},
+						},
+					},
+					TypeParams: map[string]*types.Type{
+						"T": {
+							Name: types.Name{
+								Name: "any",
+							},
+							Kind: types.Interface,
+						},
+					},
+				}
+				return &types.Type{
+					Name: types.Name{
+						Package: "k8s.io/gengo/v2/parser/testdata/generic-field",
+						Name:    "Foo",
+					},
+					Kind:                      types.Struct,
+					CommentLines:              []string{""},
+					SecondClosestCommentLines: []string{""},
+					Members: []types.Member{
+						{
+							Name:         "B",
+							Embedded:     false,
+							CommentLines: []string{""},
+							Tags:         `json:"b"`,
+							Type:         fieldType,
+						},
+					},
+					TypeParams: map[string]*types.Type{},
+				}
+			},
+		},
+		{
 			description: "generic multiple",
 			testFile:    "./testdata/generic-multi",
 			expected: func() *types.Type {

--- a/v2/parser/parse_test.go
+++ b/v2/parser/parse_test.go
@@ -1029,12 +1029,20 @@ func TestStructParse(t *testing.T) {
 				recursiveT := &types.Type{
 					Name: types.Name{
 						Package: "k8s.io/gengo/v2/parser/testdata/generic-recursive",
-						Name:    "DeepCopyable",
+						Name:    "DeepCopyable[T]",
 					},
 					Kind:                      types.Interface,
 					CommentLines:              []string{""},
 					SecondClosestCommentLines: []string{""},
 					Methods:                   map[string]*types.Type{},
+					TypeParams: map[string]*types.Type{
+						"T": {
+							Name: types.Name{
+								Name: "any",
+							},
+							Kind: types.Interface,
+						},
+					},
 				}
 				recursiveT.Methods["DeepCopy"] = &types.Type{
 					Name: types.Name{

--- a/v2/parser/testdata/generic-field/file.go
+++ b/v2/parser/testdata/generic-field/file.go
@@ -1,0 +1,10 @@
+package foo
+
+type Blah[T any] struct {
+	// V is the first field.
+	V T `json:"v"`
+}
+
+type Foo struct {
+	B Blah[string] `json:"b"`
+}


### PR DESCRIPTION
We had a regression with the deepcopy gen not being able to handle generic fields.

```
type Foo struct {
   field set.Set[string]
}
```

This fixes the name to not be trimmed for generics in `goNameToName` and also fixes a bug with named interfaces capturing generics not capturing generics properly. 