### PR TITLE
Add in defaulter tests from prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ test:
 	go test -race ./...
 	go -C v2 test -race ./...
 	(cd v2 && ./hack/verify-examples.sh)
+	(cd ./examples/defaulter-gen/_output_tests && go test -v -race ./...)
 
 # We verify for the maximum version of the go directive as 1.20
 # here because the oldest go directive that exists on our supported


### PR DESCRIPTION
Noticed that we specifically test defaulter-gen in prow and add it back in the Makefile. I believe it is not captured in `go test ./...` because the directory has a separate go mod file. 

https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/gengo/gengo-config.yaml#L20

/assign @thockin @jpbetz