### PR TITLE
Performance: Use FormatOnly on imports

### DIFF
--- a/v2/generator/execute.go
+++ b/v2/generator/execute.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/imports"
+
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
 	"k8s.io/klog/v2"
@@ -114,7 +115,13 @@ func assembleGoFile(w io.Writer, f *File) {
 }
 
 func importsWrapper(src []byte) ([]byte, error) {
-	return imports.Process("", src, nil)
+	opt := imports.Options{
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+		FormatOnly: true, // Disable the insertion and deletion of imports
+	}
+	return imports.Process("", src, &opt)
 }
 
 func NewGoFile() *DefaultFileType {

--- a/v2/generator/import_tracker.go
+++ b/v2/generator/import_tracker.go
@@ -18,6 +18,7 @@ package generator
 
 import (
 	"go/token"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -45,7 +46,7 @@ import (
 func NewImportTrackerForPackage(local string, typesToAdd ...*types.Type) *namer.DefaultImportTracker {
 	tracker := namer.NewDefaultImportTracker(types.Name{Package: local})
 	tracker.IsInvalidType = func(*types.Type) bool { return false }
-	tracker.LocalName = func(name types.Name) string { return goTrackerLocalName(&tracker, name) }
+	tracker.LocalName = func(name types.Name) string { return goTrackerLocalName(&tracker, local, name) }
 	tracker.PrintImport = func(path, name string) string { return name + " \"" + path + "\"" }
 
 	tracker.AddTypes(typesToAdd...)
@@ -56,7 +57,7 @@ func NewImportTracker(typesToAdd ...*types.Type) *namer.DefaultImportTracker {
 	return NewImportTrackerForPackage("", typesToAdd...)
 }
 
-func goTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
+func goTrackerLocalName(tracker namer.ImportTracker, localPkg string, t types.Name) string {
 	path := t.Package
 
 	// Using backslashes in package names causes gengo to produce Go code which
@@ -64,6 +65,7 @@ func goTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 	if strings.ContainsRune(path, '\\') {
 		klog.Warningf("Warning: backslash used in import path '%v', this is unsupported.\n", path)
 	}
+	localLeaf := filepath.Base(localPkg)
 
 	dirs := strings.Split(path, namer.GoSeperator)
 	for n := len(dirs) - 1; n >= 0; n-- {
@@ -74,8 +76,13 @@ func goTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 		// packages, but aren't legal go names. So we'll sanitize.
 		name = strings.ReplaceAll(name, ".", "")
 		name = strings.ReplaceAll(name, "-", "")
-		if _, found := tracker.PathOf(name); found {
-			// This name collides with some other package
+		if _, found := tracker.PathOf(name); found || name == localLeaf {
+			// This name collides with some other package.
+			// Or, this name is tne same name as the local package,
+			// which we avoid because it can be confusing. For example,
+			// if the local package is v1, we to avoid importing
+			// another package using the v1 name, and instead import
+			// it with a more qualified name, such as metav1.
 			continue
 		}
 

--- a/v2/generator/import_tracker_test.go
+++ b/v2/generator/import_tracker_test.go
@@ -72,7 +72,7 @@ func TestNewImportTracker(t *testing.T) {
 				{Name: types.Name{Package: "bar.com/external/pkg"}},
 			},
 			expectedImports: []string{
-				`pkg "bar.com/external/pkg"`,
+				`externalpkg "bar.com/external/pkg"`,
 			},
 		},
 	}


### PR DESCRIPTION
Revive https://github.com/kubernetes/kubernetes/commit/f63343f78a396615e09b15098c6b82f84178c08a.

This has a net improvement of about 26% for `hack/update-codegen.sh`: https://gist.github.com/jpbetz/227c38304fd168aa27505d5407800a74

This is dramatically faster for gengo executions with many small targets.