### PR TITLE
Ignore Go workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@
 *.un~
 Session.vim
 .netrwhist
+
+# Go workspace file
+go.work
+go.work.sum


### PR DESCRIPTION
Need to use go workspace in editor when developing the ./v2 module. 
Add `go.work` and `go.work.sum` to .gitignore.