### PR TITLE
parser/test: fix bug in comparison

### DIFF
--- a/v2/parser/parse_test.go
+++ b/v2/parser/parse_test.go
@@ -1123,7 +1123,7 @@ func TestStructParse(t *testing.T) {
 				t.Errorf("type %s did not have GoType", expected.Name.Name)
 			}
 			opts := []cmp.Option{
-				cmpopts.IgnoreTypes(types.Type{}, "GoType"),
+				cmpopts.IgnoreFields(types.Type{}, "GoType"),
 			}
 			if e, a := expected, st; !cmp.Equal(e, a, opts...) {
 				t.Errorf("wanted, got:\n%#v\n%#v\n%s", e, a, cmp.Diff(e, a, opts...))


### PR DESCRIPTION
Uses IgnoreFields instead of IgnoreTypes to ensure the expectations are correctly asserted. The assertion was broken by 1244d31, which caused all fields in `expected` to be ignored and not just `GoType`.