### PR TITLE
Extend named parser to also parse chained tags

### DIFF
--- a/v2/codetags/extractor.go
+++ b/v2/codetags/extractor.go
@@ -76,7 +76,7 @@ func findNameEnd(s string) int {
 		return 0
 	}
 	idx := strings.IndexFunc(s, func(r rune) bool {
-		return !(isIdentInterior(r) || r == ':')
+		return !(isTagNameInterior(r))
 	})
 	if idx == -1 {
 		return len(s)

--- a/v2/codetags/extractor.go
+++ b/v2/codetags/extractor.go
@@ -36,18 +36,18 @@ import (
 // Example: When called with prefix "+k8s:", lines:
 //
 //	Comment line without marker
-//	+k8s:noArgs // comment
+//	+k8s:noArgs # comment
 //	+withValue=value1
 //	+withValue=value2
 //	+k8s:withArg(arg1)=value1
-//	+k8s:withArg(arg2)=value2 // comment
+//	+k8s:withArg(arg2)=value2 # comment
 //	+k8s:withNamedArgs(arg1=value1, arg2=value2)=value
 //
 // Then this function will return:
 //
 //	map[string][]string{
-//		"noArgs":        {"noArgs // comment"},
-//		"withArg":       {"withArg(arg1)=value1", "withArg(arg2)=value2 // comment"},
+//		"noArgs":        {"noArgs # comment"},
+//		"withArg":       {"withArg(arg1)=value1", "withArg(arg2)=value2 # comment"},
 //		"withNamedArgs": {"withNamedArgs(arg1=value1, arg2=value2)=value"},
 //	}
 func Extract(prefix string, lines []string) map[string][]string {

--- a/v2/codetags/extractor_test.go
+++ b/v2/codetags/extractor_test.go
@@ -256,7 +256,7 @@ func TestExtractAndParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out := map[string][]TypedTag{}
 			for name, matchedTags := range Extract("+", tc.comments) {
-				parsed, err := ParseAll(matchedTags, ParseOptions{})
+				parsed, err := ParseAll(matchedTags)
 				if err != nil {
 					t.Fatalf("case %q: unexpected error: %v", tc.name, err)
 				}

--- a/v2/codetags/extractor_test.go
+++ b/v2/codetags/extractor_test.go
@@ -256,7 +256,7 @@ func TestExtractAndParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out := map[string][]TypedTag{}
 			for name, matchedTags := range Extract("+", tc.comments) {
-				parsed, err := ParseAll(matchedTags)
+				parsed, err := ParseAll(matchedTags, ParseOptions{})
 				if err != nil {
 					t.Fatalf("case %q: unexpected error: %v", tc.name, err)
 				}

--- a/v2/codetags/extractor_test.go
+++ b/v2/codetags/extractor_test.go
@@ -147,12 +147,12 @@ func TestExtract(t *testing.T) {
 }
 
 func TestExtractAndParse(t *testing.T) {
-	mktags := func(t ...TypedTag) []TypedTag { return t }
+	mktags := func(t ...Tag) []Tag { return t }
 
 	cases := []struct {
 		name     string
 		comments []string
-		expect   map[string][]TypedTag
+		expect   map[string][]Tag
 	}{
 		{
 			name: "positional params",
@@ -168,54 +168,54 @@ func TestExtractAndParse(t *testing.T) {
 				"+true(true)",
 				"+false(false)",
 			},
-			expect: map[string][]TypedTag{
+			expect: map[string][]Tag{
 				"quoted": mktags(
-					TypedTag{Name: "quoted", Args: []Arg{
+					Tag{Name: "quoted", Args: []Arg{
 						{Value: "value", Type: ArgTypeString},
 					}},
 				),
 				"backticked": mktags(
-					TypedTag{Name: "backticked", Args: []Arg{
+					Tag{Name: "backticked", Args: []Arg{
 						{Value: "value", Type: ArgTypeString},
 					}},
 				),
 				"ident": mktags(
-					TypedTag{Name: "ident", Args: []Arg{
+					Tag{Name: "ident", Args: []Arg{
 						{Value: "value", Type: ArgTypeString},
 					}},
 				),
 				"integer": mktags(
-					TypedTag{Name: "integer", Args: []Arg{
+					Tag{Name: "integer", Args: []Arg{
 						{Value: "2", Type: ArgTypeInt},
 					}},
 				),
 				"negative": mktags(
-					TypedTag{Name: "negative", Args: []Arg{
+					Tag{Name: "negative", Args: []Arg{
 						{Value: "-5", Type: ArgTypeInt},
 					}},
 				),
 				"hex": mktags(
-					TypedTag{Name: "hex", Args: []Arg{
+					Tag{Name: "hex", Args: []Arg{
 						{Value: "0xFF00B3", Type: ArgTypeInt},
 					}},
 				),
 				"octal": mktags(
-					TypedTag{Name: "octal", Args: []Arg{
+					Tag{Name: "octal", Args: []Arg{
 						{Value: "0o04167", Type: ArgTypeInt},
 					}},
 				),
 				"binary": mktags(
-					TypedTag{Name: "binary", Args: []Arg{
+					Tag{Name: "binary", Args: []Arg{
 						{Value: "0b10101", Type: ArgTypeInt},
 					}},
 				),
 				"true": mktags(
-					TypedTag{Name: "true", Args: []Arg{
+					Tag{Name: "true", Args: []Arg{
 						{Value: "true", Type: ArgTypeBool},
 					}},
 				),
 				"false": mktags(
-					TypedTag{Name: "false", Args: []Arg{
+					Tag{Name: "false", Args: []Arg{
 						{Value: "false", Type: ArgTypeBool},
 					}},
 				),
@@ -228,15 +228,15 @@ func TestExtractAndParse(t *testing.T) {
 				"+numbers(n1: 2, n2: -5, n3: 0xFF00B3, n4: 0o04167, n5: 0b10101)",
 				"+bools(t: true, f:false)",
 			},
-			expect: map[string][]TypedTag{
+			expect: map[string][]Tag{
 				"strings": mktags(
-					TypedTag{Name: "strings", Args: []Arg{
+					Tag{Name: "strings", Args: []Arg{
 						{Name: "q", Value: "value", Type: ArgTypeString},
 						{Name: "b", Value: `value`, Type: ArgTypeString},
 						{Name: "i", Value: "value", Type: ArgTypeString},
 					}}),
 				"numbers": mktags(
-					TypedTag{Name: "numbers", Args: []Arg{
+					Tag{Name: "numbers", Args: []Arg{
 						{Name: "n1", Value: "2", Type: ArgTypeInt},
 						{Name: "n2", Value: "-5", Type: ArgTypeInt},
 						{Name: "n3", Value: "0xFF00B3", Type: ArgTypeInt},
@@ -244,7 +244,7 @@ func TestExtractAndParse(t *testing.T) {
 						{Name: "n5", Value: "0b10101", Type: ArgTypeInt},
 					}}),
 				"bools": mktags(
-					TypedTag{Name: "bools", Args: []Arg{
+					Tag{Name: "bools", Args: []Arg{
 						{Name: "t", Value: "true", Type: ArgTypeBool},
 						{Name: "f", Value: "false", Type: ArgTypeBool},
 					}}),
@@ -254,7 +254,7 @@ func TestExtractAndParse(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := map[string][]TypedTag{}
+			out := map[string][]Tag{}
 			for name, matchedTags := range Extract("+", tc.comments) {
 				parsed, err := ParseAll(matchedTags)
 				if err != nil {

--- a/v2/codetags/parser.go
+++ b/v2/codetags/parser.go
@@ -267,6 +267,8 @@ parseLoop:
 				}
 				tag.WriteString(ident)
 				st = stMaybeArgs
+			default:
+				break parseLoop
 			}
 		case stMaybeArgs:
 			switch {

--- a/v2/codetags/parser.go
+++ b/v2/codetags/parser.go
@@ -19,7 +19,6 @@ package codetags
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 	"unicode"
 )
@@ -175,12 +174,8 @@ func parseTag(input string, opts parseOpts) (TypedTag, error) {
 
 	saveInt := func() error {
 		s := buf.String()
-		if _, err := strconv.ParseInt(s, 0, 64); err != nil {
-			return fmt.Errorf("invalid number %q", s)
-		} else {
-			cur.Value = s
-			cur.Type = ArgTypeInt
-		}
+		cur.Value = s
+		cur.Type = ArgTypeInt
 		args = append(args, cur)
 		cur = Arg{}
 		buf.Reset()

--- a/v2/codetags/parser.go
+++ b/v2/codetags/parser.go
@@ -71,7 +71,7 @@ import (
 //
 // For example,
 //
-//	"name" // no value
+//	"name" # no value
 //	"name=identifier"
 //	"name="double-quoted value""
 //	"name=`backtick-quoted value`"
@@ -85,7 +85,7 @@ import (
 //
 // For example,
 //
-//	"key=value // This comment is ignored"
+//	"key=value # This comment is ignored"
 //
 // Formal Grammar:
 //
@@ -217,7 +217,7 @@ func parseTag(input string, opts parseOpts) (Tag, error) {
 parseLoop:
 	for r := s.peek(); r != EOF; r = s.peek() {
 		switch st {
-		case stTag:
+		case stTag: // Any leading whitespace is expected to be trimmed before parsing.
 			switch {
 			case isIdentBegin(r):
 				tagName, err = s.nextIdent(isTagNameInterior)

--- a/v2/codetags/parser.go
+++ b/v2/codetags/parser.go
@@ -523,12 +523,11 @@ parseLoop:
 	if err := saveTag(); err != nil {
 		return TypedTag{}, err
 	}
-
 	if hasValue {
 		saveValue()
 	}
 	if startTag == nil {
-		return TypedTag{}, fmt.Errorf("unexpected internal parser error: no start tag")
+		return TypedTag{}, fmt.Errorf("unexpected internal parser error: no tags parsed")
 	}
 	return *startTag, nil
 }

--- a/v2/codetags/parser.go
+++ b/v2/codetags/parser.go
@@ -162,7 +162,7 @@ func parseTag(input string, opts ParseOptions) (TypedTag, error) {
 	var startTag, endTag *TypedTag // both ends of the chain when parsing chained tags
 
 	tag := bytes.Buffer{}   // current tag name
-	args := []Arg{}         // all tag arguments
+	var args []Arg          // all tag arguments
 	value := bytes.Buffer{} // current tag value
 	var valueType ValueType // current value type
 	var hasValue bool       // true if the tag has a value
@@ -237,7 +237,7 @@ func parseTag(input string, opts ParseOptions) (TypedTag, error) {
 			endTag.ValueType = ValueTypeTag
 			endTag = newTag
 		}
-		args = []Arg{}
+		args = nil // Reset to nil instead of empty slice
 		tag.Reset()
 		return nil
 	}
@@ -523,6 +523,7 @@ parseLoop:
 	if err := saveTag(); err != nil {
 		return TypedTag{}, err
 	}
+
 	if hasValue {
 		saveValue()
 	}

--- a/v2/codetags/parser_test.go
+++ b/v2/codetags/parser_test.go
@@ -64,12 +64,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:   "name with comment",
-			input:  "name // comment",
+			input:  "name # comment",
 			expect: mkt("name"),
 		},
 		{
 			name:   "name with comment after extra spaces",
-			input:  "name \t // comment",
+			input:  "name \t # comment",
 			expect: mkt("name"),
 		},
 		{
@@ -118,7 +118,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:   "argument with comment",
-			input:  "name(arg) // comment",
+			input:  "name(arg) # comment",
 			expect: mkta("name", mksa("arg")),
 		},
 		{
@@ -392,32 +392,32 @@ func TestParse(t *testing.T) {
 		// Scalar values with comments
 		{
 			name:   "integer value with comment",
-			input:  `key=1 // comment`,
+			input:  `key=1 # comment`,
 			expect: mktv("key", "1", ValueTypeInt),
 		},
 		{
 			name:   "true value with comment",
-			input:  `key=true // comment`,
+			input:  `key=true # comment`,
 			expect: mktv("key", "true", ValueTypeBool),
 		},
 		{
 			name:   "false value with comment",
-			input:  `key=false // comment`,
+			input:  `key=false # comment`,
 			expect: mktv("key", "false", ValueTypeBool),
 		},
 		{
 			name:   "identifier value with comment",
-			input:  `key=ident // comment`,
+			input:  `key=ident # comment`,
 			expect: mktv("key", "ident", ValueTypeString),
 		},
 		{
 			name:   "quoted string value with comment",
-			input:  `key="quoted" // comment`,
+			input:  `key="quoted" # comment`,
 			expect: mktv("key", "quoted", ValueTypeString),
 		},
 		{
 			name:   "backtick string value with comment",
-			input:  "key=`quoted` // comment",
+			input:  "key=`quoted` # comment",
 			expect: mktv("key", "quoted", ValueTypeString),
 		},
 
@@ -458,22 +458,22 @@ func TestParse(t *testing.T) {
 		// Tag values with comments
 		{
 			name:   "simple tag value with comment",
-			input:  `key=+key2 // comment`,
+			input:  `key=+key2 # comment`,
 			expect: mktt("key", &Tag{Name: "key2"}),
 		},
 		{
 			name:   "tag value with empty parentheses and comment",
-			input:  `key=+key2() // comment`,
+			input:  `key=+key2() # comment`,
 			expect: mktt("key", &Tag{Name: "key2"}),
 		},
 		{
 			name:   "tag value with argument and comment",
-			input:  `key=+key2(arg) // comment`,
+			input:  `key=+key2(arg) # comment`,
 			expect: mktt("key", &Tag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
 		},
 		{
 			name:  "tag value with named arguments and comment",
-			input: `key=+key2(k1: v1, k2: v2) // comment`,
+			input: `key=+key2(k1: v1, k2: v2) # comment`,
 			expect: mktt("key", &Tag{Name: "key2", Args: []Arg{
 				{Name: "k1", Value: "v1", Type: ArgTypeString},
 				{Name: "k2", Value: "v2", Type: ArgTypeString},
@@ -481,7 +481,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "3 level nested tag values with comment",
-			input: `key=+key2=+key3 // comment`,
+			input: `key=+key2=+key3 # comment`,
 			expect: mktt("key", &Tag{
 				Name:      "key2",
 				ValueType: ValueTypeTag,
@@ -534,9 +534,9 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:         "raw value with comment",
-			input:        `key=true // comment`,
+			input:        `key=true # comment`,
 			parseOptions: []ParseOption{RawValues(true)},
-			expect:       mktv("key", "true // comment", ValueTypeRaw),
+			expect:       mktv("key", "true # comment", ValueTypeRaw),
 		},
 		{
 			name:         "raw value with tag syntax",

--- a/v2/codetags/parser_test.go
+++ b/v2/codetags/parser_test.go
@@ -33,27 +33,27 @@ func TestParse(t *testing.T) {
 		return args
 	}
 
-	mkt := func(name string) TypedTag {
-		return TypedTag{Name: name}
+	mkt := func(name string) Tag {
+		return Tag{Name: name}
 	}
 
-	mkta := func(name string, args []Arg) TypedTag {
-		return TypedTag{Name: name, Args: args}
+	mkta := func(name string, args []Arg) Tag {
+		return Tag{Name: name, Args: args}
 	}
 
-	mktv := func(name, value string, valueType ValueType) TypedTag {
-		return TypedTag{Name: name, Value: value, ValueType: valueType}
+	mktv := func(name, value string, valueType ValueType) Tag {
+		return Tag{Name: name, Value: value, ValueType: valueType}
 	}
 
-	mktt := func(name string, valueTag *TypedTag) TypedTag {
-		return TypedTag{Name: name, ValueTag: valueTag, ValueType: ValueTypeTag}
+	mktt := func(name string, valueTag *Tag) Tag {
+		return Tag{Name: name, ValueTag: valueTag, ValueType: ValueTypeTag}
 	}
 
 	cases := []struct {
 		name         string
 		input        string
 		parseOptions []ParseOption
-		expect       TypedTag
+		expect       Tag
 		wantError    string // substring natch
 	}{
 		// Basic tag name tests
@@ -365,22 +365,22 @@ func TestParse(t *testing.T) {
 		{
 			name:   "simple tag value",
 			input:  `key=+key2`,
-			expect: mktt("key", &TypedTag{Name: "key2"}),
+			expect: mktt("key", &Tag{Name: "key2"}),
 		},
 		{
 			name:   "tag value with empty parentheses",
 			input:  `key=+key2()`,
-			expect: mktt("key", &TypedTag{Name: "key2"}),
+			expect: mktt("key", &Tag{Name: "key2"}),
 		},
 		{
 			name:   "tag value with argument",
 			input:  `key=+key2(arg)`,
-			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
+			expect: mktt("key", &Tag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
 		},
 		{
 			name:  "tag value with named arguments",
 			input: `key=+key2(k1: v1, k2: v2)`,
-			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{
+			expect: mktt("key", &Tag{Name: "key2", Args: []Arg{
 				{Name: "k1", Value: "v1", Type: ArgTypeString},
 				{Name: "k2", Value: "v2", Type: ArgTypeString},
 			}}),
@@ -388,10 +388,10 @@ func TestParse(t *testing.T) {
 		{
 			name:  "nested tag values",
 			input: `key=+key2=+key3`,
-			expect: mktt("key", &TypedTag{
+			expect: mktt("key", &Tag{
 				Name:      "key2",
 				ValueType: ValueTypeTag,
-				ValueTag:  &TypedTag{Name: "key3"},
+				ValueTag:  &Tag{Name: "key3"},
 			}),
 		},
 
@@ -399,22 +399,22 @@ func TestParse(t *testing.T) {
 		{
 			name:   "simple tag value with comment",
 			input:  `key=+key2 // comment`,
-			expect: mktt("key", &TypedTag{Name: "key2"}),
+			expect: mktt("key", &Tag{Name: "key2"}),
 		},
 		{
 			name:   "tag value with empty parentheses and comment",
 			input:  `key=+key2() // comment`,
-			expect: mktt("key", &TypedTag{Name: "key2"}),
+			expect: mktt("key", &Tag{Name: "key2"}),
 		},
 		{
 			name:   "tag value with argument and comment",
 			input:  `key=+key2(arg) // comment`,
-			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
+			expect: mktt("key", &Tag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
 		},
 		{
 			name:  "tag value with named arguments and comment",
 			input: `key=+key2(k1: v1, k2: v2) // comment`,
-			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{
+			expect: mktt("key", &Tag{Name: "key2", Args: []Arg{
 				{Name: "k1", Value: "v1", Type: ArgTypeString},
 				{Name: "k2", Value: "v2", Type: ArgTypeString},
 			}}),
@@ -422,41 +422,41 @@ func TestParse(t *testing.T) {
 		{
 			name:  "3 level nested tag values with comment",
 			input: `key=+key2=+key3 // comment`,
-			expect: mktt("key", &TypedTag{
+			expect: mktt("key", &Tag{
 				Name:      "key2",
 				ValueType: ValueTypeTag,
-				ValueTag:  &TypedTag{Name: "key3"},
+				ValueTag:  &Tag{Name: "key3"},
 			}),
 		},
 		{
 			name:  "4 level nested tag values with value",
 			input: `key=+key2=+key3=+key4=value`,
-			expect: mktt("key", &TypedTag{
+			expect: mktt("key", &Tag{
 				Name:      "key2",
 				ValueType: ValueTypeTag,
-				ValueTag: &TypedTag{
+				ValueTag: &Tag{
 					Name:      "key3",
 					ValueType: ValueTypeTag,
-					ValueTag:  &TypedTag{Name: "key4", Value: "value", ValueType: ValueTypeString},
+					ValueTag:  &Tag{Name: "key4", Value: "value", ValueType: ValueTypeString},
 				},
 			}),
 		},
 		{
 			name:  "4 level nested tag values with args",
 			input: `key(arg1)=+key2(arg2)=+key3(arg3)=+key4(arg4)`,
-			expect: TypedTag{
+			expect: Tag{
 				Name:      "key",
 				Args:      []Arg{{Value: "arg1", Type: ArgTypeString}},
 				ValueType: ValueTypeTag,
-				ValueTag: &TypedTag{
+				ValueTag: &Tag{
 					Name:      "key2",
 					Args:      []Arg{{Value: "arg2", Type: ArgTypeString}},
 					ValueType: ValueTypeTag,
-					ValueTag: &TypedTag{
+					ValueTag: &Tag{
 						Name:      "key3",
 						Args:      []Arg{{Value: "arg3", Type: ArgTypeString}},
 						ValueType: ValueTypeTag,
-						ValueTag: &TypedTag{
+						ValueTag: &Tag{
 							Name: "key4",
 							Args: []Arg{{Value: "arg4", Type: ArgTypeString}},
 						},
@@ -488,7 +488,7 @@ func TestParse(t *testing.T) {
 			name:         "raw with key only",
 			input:        `key`,
 			parseOptions: []ParseOption{RawValues(true)},
-			expect:       TypedTag{Name: "key"},
+			expect:       Tag{Name: "key"},
 		},
 		{
 			name:         "raw with empty value",

--- a/v2/codetags/parser_test.go
+++ b/v2/codetags/parser_test.go
@@ -176,7 +176,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "space in argument",
 			input:     "name(has space)",
-			wantError: "unexpected character 's'",
+			wantError: "unexpected character ' '",
 		},
 		{
 			name:      "multiple positional args",
@@ -191,7 +191,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "unclosed raw string",
 			input:     "badRaw(missing`)",
-			wantError: "unterminated string",
+			wantError: "unexpected character '`'",
 		},
 		{
 			name:      "nested: comma-separated args",
@@ -201,7 +201,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "nested: unclosed raw string",
 			input:     "name=+badRaw(missing`)",
-			wantError: "unterminated string",
+			wantError: "unexpected character '`'",
 		},
 
 		// Named arguments tests

--- a/v2/codetags/parser_test.go
+++ b/v2/codetags/parser_test.go
@@ -30,158 +30,427 @@ func TestParse(t *testing.T) {
 		return args
 	}
 
-	cases := []struct {
-		input           string
-		parseOptions    *ParseOptions
-		expectKey       string
-		expectArgs      []Arg
-		expectValue     string
-		expectValueType ValueType
-		expectValueTag  *TypedTag
-		err             bool
-	}{
-		// string args
-		{input: "name", expectKey: "name"},
-		{input: "name // comment", expectKey: "name"},
-		{input: "name-dash", expectKey: "name-dash"},
-		{input: "name.dot", expectKey: "name.dot"},
-		{input: "name:colon", expectKey: "name:colon"},
-		{input: "name()", expectKey: "name"},
-		{input: "name(arg)", expectKey: "name", expectArgs: mksa("arg")},
-		{input: "name(arg) // comment", expectKey: "name", expectArgs: mksa("arg")},
-		{input: "name(ARG)", expectKey: "name", expectArgs: mksa("ARG")},
-		{input: "name(ArG)", expectKey: "name", expectArgs: mksa("ArG")},
-		{input: "name(has-dash)", expectKey: "name", expectArgs: mksa("has-dash")},
-		{input: "name(has.dot)", expectKey: "name", expectArgs: mksa("has.dot")},
-		{input: "name()", expectKey: "name"},
-		{input: "name(lower)", expectKey: "name", expectArgs: mksa("lower")},
-		{input: "name(CAPITAL)", expectKey: "name", expectArgs: mksa("CAPITAL")},
-		{input: "name(MiXeD)", expectKey: "name", expectArgs: mksa("MiXeD")},
-		{input: "name(mIxEd)", expectKey: "name", expectArgs: mksa("mIxEd")},
-		{input: "name(_under)", expectKey: "name", expectArgs: mksa("_under")},
-		{input: `name("hasQuotes")`, expectKey: "name", expectArgs: mksa("hasQuotes")},
-		{input: "name(`hasRawQuotes`)", expectKey: "name", expectArgs: mksa("hasRawQuotes")},
-		{input: "name(has space)", expectKey: "name", err: true},
-		{input: "name(multiple, args)", expectKey: "name", err: true},
-		{input: "name(noClosingParen", expectKey: "name", err: true},
-		{input: "withRaw(`a = b`)", expectKey: "withRaw", expectArgs: mksa("a = b")},
-
-		// invalid args
-		{input: "name(arg1, arg2)", err: true},
-		{input: "badRaw(missing`)", err: true},
-		{input: "badMix(arg,`raw`)", err: true},
-		{input: "name=+name(arg1, arg2)", err: true},
-		{input: "name=+badRaw(missing`)", err: true},
-		{input: "name=+badMix(arg,`raw`)", err: true},
-
-		// quotes
-		{input: `quoted(s: "value \" \\")`, expectKey: "quoted", expectArgs: []Arg{
-			{Name: "s", Value: "value \" \\", Type: ArgTypeString},
-		}},
-		{input: "backticks(s: `value`)", expectKey: "backticks", expectArgs: []Arg{
-			{Name: "s", Value: `value`, Type: ArgTypeString},
-		}},
-		{input: "ident(k: value)", expectKey: "ident", expectArgs: []Arg{
-			{Name: "k", Value: "value", Type: ArgTypeString},
-		}},
-
-		// numbers
-		{input: "numbers(n1: 2, n2: -5, n3: 0xFF00B3, n4: 0o04167, n5: 0b10101)", expectKey: "numbers", expectArgs: []Arg{
-			{Name: "n1", Value: "2", Type: ArgTypeInt},
-			{Name: "n2", Value: "-5", Type: ArgTypeInt},
-			{Name: "n3", Value: "0xFF00B3", Type: ArgTypeInt},
-			{Name: "n4", Value: "0o04167", Type: ArgTypeInt},
-			{Name: "n5", Value: "0b10101", Type: ArgTypeInt},
-		}},
-
-		// bools
-		{input: "bools(t: true, f:false)", expectKey: "bools", expectArgs: []Arg{
-			{Name: "t", Value: "true", Type: ArgTypeBool},
-			{Name: "f", Value: "false", Type: ArgTypeBool},
-		}},
-
-		// mixed type args
-		{input: "mixed(s: `value`, i: 2, b: true)", expectKey: "mixed", expectArgs: []Arg{
-			{Name: "s", Value: "value", Type: ArgTypeString},
-			{Name: "i", Value: "2", Type: ArgTypeInt},
-			{Name: "b", Value: "true", Type: ArgTypeBool},
-		}},
-
-		// scalar values
-		{input: `key=1`, expectKey: "key", expectValue: "1", expectValueType: ValueTypeInt},
-		{input: `key=true`, expectKey: "key", expectValue: "true", expectValueType: ValueTypeBool},
-		{input: `key=false`, expectKey: "key", expectValue: "false", expectValueType: ValueTypeBool},
-		{input: `key=ident`, expectKey: "key", expectValue: "ident", expectValueType: ValueTypeString},
-		{input: `key="quoted"`, expectKey: "key", expectValue: "quoted", expectValueType: ValueTypeString},
-		{input: "key=`quoted`", expectKey: "key", expectValue: "quoted", expectValueType: ValueTypeString},
-
-		// scalar values with comments
-		{input: `key=1 // comment`, expectKey: "key", expectValue: "1", expectValueType: ValueTypeInt},
-		{input: `key=true // comment`, expectKey: "key", expectValue: "true", expectValueType: ValueTypeBool},
-		{input: `key=false // comment`, expectKey: "key", expectValue: "false", expectValueType: ValueTypeBool},
-		{input: `key=ident // comment`, expectKey: "key", expectValue: "ident", expectValueType: ValueTypeString},
-		{input: `key="quoted" // comment`, expectKey: "key", expectValue: "quoted", expectValueType: ValueTypeString},
-		{input: "key=`quoted` // comment", expectKey: "key", expectValue: "quoted", expectValueType: ValueTypeString},
-
-		// tag values
-		{input: `key=+key2`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2()`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2(arg)`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2(k1: v1, k2: v2)`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{{Name: "k1", Value: "v1", Type: ArgTypeString}, {Name: "k2", Value: "v2", Type: ArgTypeString}}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2=+key3`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{}, ValueType: ValueTypeTag, ValueTag: &TypedTag{Name: "key3", Args: []Arg{}}}, expectValueType: ValueTypeTag},
-
-		// tag values with comments
-		{input: `key=+key2 // comment`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2() // comment`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2(arg) // comment`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2(k1: v1, k2: v2) // comment`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{{Name: "k1", Value: "v1", Type: ArgTypeString}, {Name: "k2", Value: "v2", Type: ArgTypeString}}}, expectValueType: ValueTypeTag},
-		{input: `key=+key2=+key3 // comment`, expectKey: "key", expectValueTag: &TypedTag{Name: "key2", Args: []Arg{}, ValueType: ValueTypeTag, ValueTag: &TypedTag{Name: "key3", Args: []Arg{}}}, expectValueType: ValueTypeTag},
-
-		// raw values
-		{input: `key=this is \ arbitrary content !!`, parseOptions: &ParseOptions{RawValues: true}, expectKey: "key", expectValue: "this is \\ arbitrary content !!", expectValueType: ValueTypeRaw},
-		{input: `key=true // comment`, parseOptions: &ParseOptions{RawValues: true}, expectKey: "key", expectValue: "true // comment", expectValueType: ValueTypeRaw},
-		{input: `key=+key2`, parseOptions: &ParseOptions{RawValues: true}, expectKey: "key", expectValue: "+key2", expectValueType: ValueTypeRaw},
-		{input: `key`, parseOptions: &ParseOptions{RawValues: true}, expectKey: "key", expectValueType: ""},
-		{input: `key=`, parseOptions: &ParseOptions{RawValues: true}, expectKey: "key", expectValueType: ValueTypeRaw},
+	mkt := func(name string) TypedTag {
+		return TypedTag{Name: name}
 	}
+
+	mkta := func(name string, args []Arg) TypedTag {
+		return TypedTag{Name: name, Args: args}
+	}
+
+	mktv := func(name, value string, valueType ValueType) TypedTag {
+		return TypedTag{Name: name, Value: value, ValueType: valueType}
+	}
+
+	mktt := func(name string, valueTag *TypedTag) TypedTag {
+		return TypedTag{Name: name, ValueTag: valueTag, ValueType: ValueTypeTag}
+	}
+
+	cases := []struct {
+		name         string
+		input        string
+		parseOptions ParseOptions
+		expect       TypedTag
+		err          bool
+	}{
+		// Basic tag name tests
+		{
+			name:   "simple name",
+			input:  "name",
+			expect: mkt("name"),
+		},
+		{
+			name:   "name with comment",
+			input:  "name // comment",
+			expect: mkt("name"),
+		},
+		{
+			name:   "name with dash",
+			input:  "name-dash",
+			expect: mkt("name-dash"),
+		},
+		{
+			name:   "name with dot",
+			input:  "name.dot",
+			expect: mkt("name.dot"),
+		},
+		{
+			name:   "name with colon",
+			input:  "name:colon",
+			expect: mkt("name:colon"),
+		},
+
+		// String arguments tests
+		{
+			name:   "empty parentheses",
+			input:  "name()",
+			expect: mkt("name"),
+		},
+		{
+			name:   "single argument",
+			input:  "name(arg)",
+			expect: mkta("name", mksa("arg")),
+		},
+		{
+			name:   "argument with comment",
+			input:  "name(arg) // comment",
+			expect: mkta("name", mksa("arg")),
+		},
+		{
+			name:   "uppercase argument",
+			input:  "name(ARG)",
+			expect: mkta("name", mksa("ARG")),
+		},
+		{
+			name:   "mixed case argument",
+			input:  "name(ArG)",
+			expect: mkta("name", mksa("ArG")),
+		},
+		{
+			name:   "argument with dash",
+			input:  "name(has-dash)",
+			expect: mkta("name", mksa("has-dash")),
+		},
+		{
+			name:   "argument with dot",
+			input:  "name(has.dot)",
+			expect: mkta("name", mksa("has.dot")),
+		},
+		{
+			name:   "lowercase argument",
+			input:  "name(lower)",
+			expect: mkta("name", mksa("lower")),
+		},
+		{
+			name:   "uppercase argument",
+			input:  "name(CAPITAL)",
+			expect: mkta("name", mksa("CAPITAL")),
+		},
+		{
+			name:   "mixed case argument 1",
+			input:  "name(MiXeD)",
+			expect: mkta("name", mksa("MiXeD")),
+		},
+		{
+			name:   "mixed case argument 2",
+			input:  "name(mIxEd)",
+			expect: mkta("name", mksa("mIxEd")),
+		},
+		{
+			name:   "underscore in argument",
+			input:  "name(_under)",
+			expect: mkta("name", mksa("_under")),
+		},
+		{
+			name:   "quoted argument",
+			input:  `name("hasQuotes")`,
+			expect: mkta("name", mksa("hasQuotes")),
+		},
+		{
+			name:   "raw quoted argument",
+			input:  "name(`hasRawQuotes`)",
+			expect: mkta("name", mksa("hasRawQuotes")),
+		},
+		{
+			name:   "raw string with spaces",
+			input:  "withRaw(`a = b`)",
+			expect: mkta("withRaw", mksa("a = b")),
+		},
+
+		// Error cases for arguments
+		{
+			name:  "space in argument",
+			input: "name(has space)",
+			err:   true,
+		},
+		{
+			name:  "multiple comma-separated args",
+			input: "name(multiple, args)",
+			err:   true,
+		},
+		{
+			name:  "unclosed parenthesis",
+			input: "name(noClosingParen",
+			err:   true,
+		},
+		{
+			name:  "comma-separated args",
+			input: "name(arg1, arg2)",
+			err:   true,
+		},
+		{
+			name:  "unclosed raw string",
+			input: "badRaw(missing`)",
+			err:   true,
+		},
+		{
+			name:  "mixed arg formats",
+			input: "badMix(arg,`raw`)",
+			err:   true,
+		},
+		{
+			name:  "nested: comma-separated args",
+			input: "name=+name(arg1, arg2)",
+			err:   true,
+		},
+		{
+			name:  "nested: unclosed raw string",
+			input: "name=+badRaw(missing`)",
+			err:   true,
+		},
+		{
+			name:  "nested: mixed arg formats",
+			input: "name=+badMix(arg,`raw`)",
+			err:   true,
+		},
+
+		// Named arguments tests
+		{
+			name:  "quoted named argument",
+			input: `quoted(s: "value \" \\")`,
+			expect: mkta("quoted", []Arg{
+				{Name: "s", Value: "value \" \\", Type: ArgTypeString},
+			}),
+		},
+		{
+			name:  "backtick named argument",
+			input: "backticks(s: `value`)",
+			expect: mkta("backticks", []Arg{
+				{Name: "s", Value: `value`, Type: ArgTypeString},
+			}),
+		},
+		{
+			name:  "identifier named argument",
+			input: "ident(k: value)",
+			expect: mkta("ident", []Arg{
+				{Name: "k", Value: "value", Type: ArgTypeString},
+			}),
+		},
+
+		// Numeric argument tests
+		{
+			name:  "numeric arguments",
+			input: "numbers(n1: 2, n2: -5, n3: 0xFF00B3, n4: 0o04167, n5: 0b10101)",
+			expect: mkta("numbers", []Arg{
+				{Name: "n1", Value: "2", Type: ArgTypeInt},
+				{Name: "n2", Value: "-5", Type: ArgTypeInt},
+				{Name: "n3", Value: "0xFF00B3", Type: ArgTypeInt},
+				{Name: "n4", Value: "0o04167", Type: ArgTypeInt},
+				{Name: "n5", Value: "0b10101", Type: ArgTypeInt},
+			}),
+		},
+
+		// Boolean argument tests
+		{
+			name:  "boolean arguments",
+			input: "bools(t: true, f:false)",
+			expect: mkta("bools", []Arg{
+				{Name: "t", Value: "true", Type: ArgTypeBool},
+				{Name: "f", Value: "false", Type: ArgTypeBool},
+			}),
+		},
+
+		// Mixed type argument tests
+		{
+			name:  "mixed type arguments",
+			input: "mixed(s: `value`, i: 2, b: true)",
+			expect: mkta("mixed", []Arg{
+				{Name: "s", Value: "value", Type: ArgTypeString},
+				{Name: "i", Value: "2", Type: ArgTypeInt},
+				{Name: "b", Value: "true", Type: ArgTypeBool},
+			}),
+		},
+
+		// Scalar value tests
+		{
+			name:   "integer value",
+			input:  `key=1`,
+			expect: mktv("key", "1", ValueTypeInt),
+		},
+		{
+			name:   "true value",
+			input:  `key=true`,
+			expect: mktv("key", "true", ValueTypeBool),
+		},
+		{
+			name:   "false value",
+			input:  `key=false`,
+			expect: mktv("key", "false", ValueTypeBool),
+		},
+		{
+			name:   "identifier value",
+			input:  `key=ident`,
+			expect: mktv("key", "ident", ValueTypeString),
+		},
+		{
+			name:   "quoted string value",
+			input:  `key="quoted"`,
+			expect: mktv("key", "quoted", ValueTypeString),
+		},
+		{
+			name:   "backtick string value",
+			input:  "key=`quoted`",
+			expect: mktv("key", "quoted", ValueTypeString),
+		},
+
+		// Scalar values with comments
+		{
+			name:   "integer value with comment",
+			input:  `key=1 // comment`,
+			expect: mktv("key", "1", ValueTypeInt),
+		},
+		{
+			name:   "true value with comment",
+			input:  `key=true // comment`,
+			expect: mktv("key", "true", ValueTypeBool),
+		},
+		{
+			name:   "false value with comment",
+			input:  `key=false // comment`,
+			expect: mktv("key", "false", ValueTypeBool),
+		},
+		{
+			name:   "identifier value with comment",
+			input:  `key=ident // comment`,
+			expect: mktv("key", "ident", ValueTypeString),
+		},
+		{
+			name:   "quoted string value with comment",
+			input:  `key="quoted" // comment`,
+			expect: mktv("key", "quoted", ValueTypeString),
+		},
+		{
+			name:   "backtick string value with comment",
+			input:  "key=`quoted` // comment",
+			expect: mktv("key", "quoted", ValueTypeString),
+		},
+
+		// Tag values
+		{
+			name:   "simple tag value",
+			input:  `key=+key2`,
+			expect: mktt("key", &TypedTag{Name: "key2"}),
+		},
+		{
+			name:   "tag value with empty parentheses",
+			input:  `key=+key2()`,
+			expect: mktt("key", &TypedTag{Name: "key2"}),
+		},
+		{
+			name:   "tag value with argument",
+			input:  `key=+key2(arg)`,
+			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
+		},
+		{
+			name:  "tag value with named arguments",
+			input: `key=+key2(k1: v1, k2: v2)`,
+			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{
+				{Name: "k1", Value: "v1", Type: ArgTypeString},
+				{Name: "k2", Value: "v2", Type: ArgTypeString},
+			}}),
+		},
+		{
+			name:  "nested tag values",
+			input: `key=+key2=+key3`,
+			expect: mktt("key", &TypedTag{
+				Name:      "key2",
+				ValueType: ValueTypeTag,
+				ValueTag:  &TypedTag{Name: "key3"},
+			}),
+		},
+
+		// Tag values with comments
+		{
+			name:   "simple tag value with comment",
+			input:  `key=+key2 // comment`,
+			expect: mktt("key", &TypedTag{Name: "key2"}),
+		},
+		{
+			name:   "tag value with empty parentheses and comment",
+			input:  `key=+key2() // comment`,
+			expect: mktt("key", &TypedTag{Name: "key2"}),
+		},
+		{
+			name:   "tag value with argument and comment",
+			input:  `key=+key2(arg) // comment`,
+			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{{Value: "arg", Type: ArgTypeString}}}),
+		},
+		{
+			name:  "tag value with named arguments and comment",
+			input: `key=+key2(k1: v1, k2: v2) // comment`,
+			expect: mktt("key", &TypedTag{Name: "key2", Args: []Arg{
+				{Name: "k1", Value: "v1", Type: ArgTypeString},
+				{Name: "k2", Value: "v2", Type: ArgTypeString},
+			}}),
+		},
+		{
+			name:  "nested tag values with comment",
+			input: `key=+key2=+key3 // comment`,
+			expect: mktt("key", &TypedTag{
+				Name:      "key2",
+				ValueType: ValueTypeTag,
+				ValueTag:  &TypedTag{Name: "key3"},
+			}),
+		},
+
+		// Raw values
+		{
+			name:         "raw arbitrary content",
+			input:        `key=this is \ arbitrary content !!`,
+			parseOptions: ParseOptions{RawValues: true},
+			expect:       mktv("key", "this is \\ arbitrary content !!", ValueTypeRaw),
+		},
+		{
+			name:         "raw value with comment",
+			input:        `key=true // comment`,
+			parseOptions: ParseOptions{RawValues: true},
+			expect:       mktv("key", "true // comment", ValueTypeRaw),
+		},
+		{
+			name:         "raw value with tag syntax",
+			input:        `key=+key2`,
+			parseOptions: ParseOptions{RawValues: true},
+			expect:       mktv("key", "+key2", ValueTypeRaw),
+		},
+		{
+			name:         "raw with key only",
+			input:        `key`,
+			parseOptions: ParseOptions{RawValues: true},
+			expect:       TypedTag{Name: "key"},
+		},
+		{
+			name:         "raw with empty value",
+			input:        `key=`,
+			parseOptions: ParseOptions{RawValues: true},
+			expect:       mktv("key", "", ValueTypeRaw),
+		},
+	}
+
 	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			parseOptions := ParseOptions{}
-			if tc.parseOptions != nil {
-				parseOptions = *tc.parseOptions
-			}
-			parsed, err := parseTag(tc.input, parseOptions)
-			if err != nil && tc.err == false {
-				t.Errorf("[%q]: expected success, got: %v", tc.input, err)
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseTag(tc.input, tc.parseOptions)
+			if err != nil {
+				if !tc.err {
+					t.Errorf("Expected success, got error: %v", err)
+				}
 				return
 			}
+			if tc.err {
+				t.Errorf("Expected error, got success: %v", parsed)
+				return
+			}
+			if !reflect.DeepEqual(parsed, tc.expect) {
+				t.Errorf("Parsed tag doesn't match expected.\nExpected: %#v\nGot: %#v", tc.expect, parsed)
+			}
 
-			if err == nil {
-				if tc.err == true {
-					t.Errorf("[%q]: expected failure, got: %v(%v)", tc.input, parsed.Name, parsed.Args)
-					return
-				}
-				if parsed.Name != tc.expectKey {
-					t.Errorf("[%q]: expected key: %q, got: %q", tc.input, tc.expectKey, parsed.Name)
-				}
-				if len(parsed.Args) != len(tc.expectArgs) {
-					t.Errorf("[%q]: expected %d args, got: %q", tc.input, len(tc.expectArgs), parsed.Args)
-					return
-				}
-				for i := range tc.expectArgs {
-					if want, got := tc.expectArgs[i], parsed.Args[i]; got != want {
-						t.Errorf("[%q]: expected %q, got %q", tc.input, want, got)
-					}
-				}
-				if parsed.Value != tc.expectValue {
-					t.Errorf("[%q]: expected value: %q, got: %q", tc.input, tc.expectValue, parsed.Value)
-				}
-				if parsed.ValueType != tc.expectValueType {
-					t.Errorf("[%q]: expected value type: %q, got: %q", tc.input, tc.expectValueType, parsed.ValueType)
-				}
-				if tc.expectValueTag != nil && !reflect.DeepEqual(tc.expectValueTag, parsed.ValueTag) {
-					t.Errorf("[%q]: expected value tag: %q, got: %q", tc.input, tc.expectValueTag.String(), parsed.ValueTag.String())
-				}
+			// round-trip testing
+			roundTripped, err := parseTag(parsed.String(), tc.parseOptions)
+			if err != nil {
+				t.Errorf("Failed to reparse tag: %v", err)
+				return
+			}
+			if !reflect.DeepEqual(roundTripped, parsed) {
+				t.Errorf("Round-tripped tag doesn't match original.\nExpected: %#v\nGot: %#v", parsed, roundTripped)
 			}
 		})
 	}

--- a/v2/codetags/parser_test.go
+++ b/v2/codetags/parser_test.go
@@ -406,12 +406,25 @@ func TestParse(t *testing.T) {
 			}}),
 		},
 		{
-			name:  "nested tag values with comment",
+			name:  "3 level nested tag values with comment",
 			input: `key=+key2=+key3 // comment`,
 			expect: mktt("key", &TypedTag{
 				Name:      "key2",
 				ValueType: ValueTypeTag,
 				ValueTag:  &TypedTag{Name: "key3"},
+			}),
+		},
+		{
+			name:  "4 level nested tag values with comment",
+			input: `key=+key2=+key3=+key4 // comment`,
+			expect: mktt("key", &TypedTag{
+				Name:      "key2",
+				ValueType: ValueTypeTag,
+				ValueTag: &TypedTag{
+					Name:      "key3",
+					ValueType: ValueTypeTag,
+					ValueTag:  &TypedTag{Name: "key4"},
+				},
 			}),
 		},
 

--- a/v2/codetags/parser_test.go
+++ b/v2/codetags/parser_test.go
@@ -68,6 +68,11 @@ func TestParse(t *testing.T) {
 			expect: mkt("name"),
 		},
 		{
+			name:   "name with comment after extra spaces",
+			input:  "name \t // comment",
+			expect: mkt("name"),
+		},
+		{
 			name:   "name with dash",
 			input:  "name-dash",
 			expect: mkt("name-dash"),
@@ -88,6 +93,16 @@ func TestParse(t *testing.T) {
 			name:      "empty value",
 			input:     "name=",
 			wantError: "unexpected end of input",
+		},
+		{
+			name:      "space before =",
+			input:     "name =x",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space after =",
+			input:     "name= x",
+			wantError: "unexpected character ' '",
 		},
 
 		// String arguments tests
@@ -203,6 +218,51 @@ func TestParse(t *testing.T) {
 			input:     "name=+badRaw(missing`)",
 			wantError: "unexpected character '`'",
 		},
+		{
+			name:      "space before (",
+			input:     "name ()",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space between ( and )",
+			input:     "name ( )",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space before arg",
+			input:     "name( x)",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space after arg",
+			input:     "name(x )",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space before :",
+			input:     "name(k :v)",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space before value",
+			input:     "name(k:v )",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space before ,",
+			input:     "name(k:v ,k2:v2)",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space before =",
+			input:     "name() =x",
+			wantError: "unexpected character ' '",
+		},
+		{
+			name:      "space after =",
+			input:     "name()= x",
+			wantError: "unexpected character ' '",
+		},
 
 		// Named arguments tests
 		{
@@ -311,7 +371,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "space in value",
 			input:     "key=one two",
-			wantError: "unexpected character 't'",
+			wantError: "unexpected character ' '",
 		},
 		{
 			name:      "unclosed backtick quoted string",

--- a/v2/codetags/scanner.go
+++ b/v2/codetags/scanner.go
@@ -67,20 +67,10 @@ const (
 )
 
 func (s *scanner) nextIsTrailingComment() bool {
-	if s.pos >= len(s.buf)-1 {
-		return false
+	i := 0
+	for ; unicode.IsSpace(s.peekN(i)); i++ {
 	}
-	for i := s.pos; i < len(s.buf)-1; i++ {
-		switch {
-		case unicode.IsSpace(s.buf[i]):
-			continue
-		case s.buf[i] == '#':
-			return true
-		default:
-			return false
-		}
-	}
-	return false
+	return s.peekN(i) == '#'
 }
 
 func (s *scanner) nextNumber() (string, error) {

--- a/v2/codetags/scanner.go
+++ b/v2/codetags/scanner.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codetags
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+type scanner struct {
+	buf []rune
+	pos int
+}
+
+func (s *scanner) next() rune {
+	if s.pos >= len(s.buf) {
+		return EOF
+	}
+	r := s.buf[s.pos]
+	s.pos++
+	return r
+}
+
+func (s *scanner) peek() rune {
+	if s.pos >= len(s.buf) {
+		return EOF
+	}
+	return s.buf[s.pos]
+}
+
+func (s *scanner) peekN(n int) rune {
+	if s.pos >= len(s.buf) {
+		return EOF
+	}
+	return s.buf[s.pos+n]
+}
+
+const (
+	EOF = -1
+)
+
+const (
+	stNumber       = "stNumber"
+	stPrefixNumber = "stPrefixNumber"
+)
+
+func (s *scanner) nextNumber() (string, error) {
+	var buf bytes.Buffer
+	var incomplete bool
+	st := stBegin
+
+parseLoop:
+	for r := s.peek(); r != EOF; r = s.peek() {
+		switch st {
+		case stBegin:
+			switch {
+			case r == '+':
+				s.next() // consume +
+			case r == '0':
+				buf.WriteRune(s.next())
+				st = stPrefixNumber
+			case r == '-' || unicode.IsDigit(r):
+				buf.WriteRune(s.next())
+				st = stNumber
+			default:
+				break parseLoop
+			}
+		case stPrefixNumber:
+			switch {
+			case unicode.IsDigit(r):
+				buf.WriteRune(s.next())
+				st = stNumber
+			case r == 'x' || r == 'o' || r == 'b':
+				incomplete = true
+				buf.WriteRune(s.next())
+				st = stNumber
+			default:
+				break parseLoop
+			}
+		case stNumber:
+			hexits := "abcdefABCDEF"
+			switch {
+			case unicode.IsDigit(r) || strings.Contains(hexits, string(r)):
+				buf.WriteRune(s.next())
+				incomplete = false
+				continue
+			default:
+				break parseLoop
+			}
+		default:
+			return "", fmt.Errorf("unexpected internal parser error: unknown state: %s at position %d", st, s.pos)
+		}
+	}
+	if incomplete {
+		return "", fmt.Errorf("unterminated number at position %d", s.pos)
+	}
+	return buf.String(), nil
+}
+
+const (
+	stQuotedString = "stQuotedString"
+	stEscape       = "stEscape"
+)
+
+func (s *scanner) nextString() (string, error) {
+	var buf bytes.Buffer
+	var quote rune
+	var incomplete bool
+	st := stBegin
+
+parseLoop:
+	for r := s.peek(); r != EOF; r = s.peek() {
+		switch st {
+		case stBegin:
+			switch {
+			case r == '"' || r == '`':
+				incomplete = true
+				quote = s.next() // consume quote
+				st = stQuotedString
+			default:
+				return "", fmt.Errorf("expected string at position %d", s.pos)
+			}
+		case stQuotedString:
+			switch {
+			case r == '\\':
+				s.next() // consume escape
+				st = stEscape
+			case r == quote:
+				incomplete = false
+				s.next()
+				break parseLoop
+			default:
+				buf.WriteRune(s.next())
+			}
+		case stEscape:
+			switch {
+			case r == quote || r == '\\':
+				buf.WriteRune(s.next())
+				st = stQuotedString
+			default:
+				return "", fmt.Errorf("unhandled escaped character %q", r)
+			}
+		default:
+			return "", fmt.Errorf("unexpected internal parser error: unknown state: %s at position %d", st, s.pos)
+		}
+	}
+	if incomplete {
+		return "", fmt.Errorf("unterminated string at position %d", s.pos)
+	}
+	return buf.String(), nil
+}
+
+const (
+	stInterior = "stInterior"
+)
+
+func (s *scanner) nextIdent(isInteriorChar func(r rune) bool) (string, error) {
+	var buf bytes.Buffer
+	st := stBegin
+
+parseLoop:
+	for r := s.peek(); r != EOF; r = s.peek() {
+		switch st {
+		case stBegin:
+			switch {
+			case isIdentBegin(r):
+				buf.WriteRune(s.next())
+				st = stInterior
+			}
+		case stInterior:
+			switch {
+			case isInteriorChar(r):
+				buf.WriteRune(s.next())
+			default:
+				break parseLoop
+			}
+		default:
+			return "", fmt.Errorf("unexpected internal parser error: unknown state: %s at position %d", st, s.pos)
+		}
+	}
+	return buf.String(), nil
+}

--- a/v2/codetags/scanner.go
+++ b/v2/codetags/scanner.go
@@ -56,23 +56,6 @@ func (s *scanner) skipWhitespace() rune {
 	return s.peek()
 }
 
-func (s *scanner) nextIsTrailingComment() bool {
-	if s.pos >= len(s.buf)-1 {
-		return false
-	}
-	for i := s.pos; i < len(s.buf)-1; i++ {
-		switch {
-		case unicode.IsSpace(s.buf[i]):
-			continue
-		case s.buf[i] == '/' && s.buf[i+1] == '/':
-			return true
-		default:
-			return false
-		}
-	}
-	return false
-}
-
 func (s *scanner) remainder() string {
 	result := string(s.buf[s.pos:])
 	s.pos = len(s.buf)
@@ -82,6 +65,23 @@ func (s *scanner) remainder() string {
 const (
 	EOF = -1
 )
+
+func (s *scanner) nextIsTrailingComment() bool {
+	if s.pos >= len(s.buf)-1 {
+		return false
+	}
+	for i := s.pos; i < len(s.buf)-1; i++ {
+		switch {
+		case unicode.IsSpace(s.buf[i]):
+			continue
+		case s.buf[i] == '#':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
 
 func (s *scanner) nextNumber() (string, error) {
 	const (

--- a/v2/codetags/scanner.go
+++ b/v2/codetags/scanner.go
@@ -49,18 +49,28 @@ func (s *scanner) peekN(n int) rune {
 	return s.buf[s.pos+n]
 }
 
-func (s *scanner) skipWhitespace() bool {
-	found := false
+func (s *scanner) skipWhitespace() rune {
 	for r := s.peek(); unicode.IsSpace(r); r = s.peek() {
 		s.next()
-		found = true
 	}
-	return found
+	return s.peek()
 }
 
-func (s *scanner) skipWhitespacePeek() rune {
-	s.skipWhitespace()
-	return s.peek()
+func (s *scanner) nextIsTrailingComment() bool {
+	if s.pos >= len(s.buf)-1 {
+		return false
+	}
+	for i := s.pos; i < len(s.buf)-1; i++ {
+		switch {
+		case unicode.IsSpace(s.buf[i]):
+			continue
+		case s.buf[i] == '/' && s.buf[i+1] == '/':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func (s *scanner) remainder() string {

--- a/v2/codetags/scanner.go
+++ b/v2/codetags/scanner.go
@@ -19,6 +19,7 @@ package codetags
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -79,7 +80,7 @@ parseLoop:
 				buf.WriteRune(s.next())
 				st = stNumber
 			default:
-				break parseLoop
+				return "", fmt.Errorf("expected number at position %d", s.pos)
 			}
 		case stPrefixNumber:
 			switch {
@@ -110,7 +111,11 @@ parseLoop:
 	if incomplete {
 		return "", fmt.Errorf("unterminated number at position %d", s.pos)
 	}
-	return buf.String(), nil
+	numStr := buf.String()
+	if _, err := strconv.ParseInt(numStr, 0, 64); err != nil {
+		return "", fmt.Errorf("invalid number %q at position %d", numStr, s.pos)
+	}
+	return numStr, nil
 }
 
 const (
@@ -182,6 +187,8 @@ parseLoop:
 			case isIdentBegin(r):
 				buf.WriteRune(s.next())
 				st = stInterior
+			default:
+				return "", fmt.Errorf("expected identifier at position %d", s.pos)
 			}
 		case stInterior:
 			switch {

--- a/v2/codetags/scanner.go
+++ b/v2/codetags/scanner.go
@@ -58,6 +58,11 @@ func (s *scanner) skipWhitespace() bool {
 	return found
 }
 
+func (s *scanner) skipWhitespacePeek() rune {
+	s.skipWhitespace()
+	return s.peek()
+}
+
 func (s *scanner) remainder() string {
 	result := string(s.buf[s.pos:])
 	s.pos = len(s.buf)
@@ -70,6 +75,7 @@ const (
 
 func (s *scanner) nextNumber() (string, error) {
 	const (
+		stBegin  = "stBegin"
 		stPrefix = "stPrefix"
 		stPosNeg = "stPosNeg"
 		stNumber = "stNumber"
@@ -137,6 +143,7 @@ parseLoop:
 
 func (s *scanner) nextString() (string, error) {
 	const (
+		stBegin        = "stBegin"
 		stQuotedString = "stQuotedString"
 		stEscape       = "stEscape"
 	)
@@ -189,6 +196,7 @@ parseLoop:
 
 func (s *scanner) nextIdent(isInteriorChar func(r rune) bool) (string, error) {
 	const (
+		stBegin    = "stBegin"
 		stInterior = "stInterior"
 	)
 	var buf bytes.Buffer

--- a/v2/codetags/scanner_test.go
+++ b/v2/codetags/scanner_test.go
@@ -69,16 +69,6 @@ func TestScannerBasics(t *testing.T) {
 				}
 				s.next() // Advance scanner
 			}
-
-			// peekN()
-			if len(tt.input) > 1 {
-				s = scanner{buf: []rune(tt.input)}
-				got := s.peekN(1)
-				want := []rune(tt.input)[1]
-				if got != want {
-					t.Errorf("peekN(1) at position 0 = %v, want %v", got, want)
-				}
-			}
 		})
 	}
 }
@@ -101,7 +91,7 @@ func TestNextNumber(t *testing.T) {
 		{
 			name:  "positive integer with plus sign",
 			input: "+123",
-			want:  "123",
+			want:  "+123",
 		},
 		{
 			name:  "zero",
@@ -112,12 +102,46 @@ func TestNextNumber(t *testing.T) {
 			input: "0xFF",
 		},
 		{
+			name:  "positive hex number",
+			input: "+0xFF",
+		},
+		{
+			name:  "negative hex number",
+			input: "-0xFF",
+		},
+		{
 			name:  "octal number",
 			input: "0o77",
 		},
 		{
+			name:  "positive octal number",
+			input: "+0o77",
+		},
+		{
+			name:  "negative octal number",
+			input: "-0o77",
+		},
+		{
 			name:  "binary number",
 			input: "0b101",
+		},
+		{
+			name:  "positive binary number",
+			input: "+0b101",
+		},
+		{
+			name:  "negative binary number",
+			input: "-0b101",
+		},
+		{
+			name:    "incomplete positive",
+			input:   "-",
+			wantErr: true,
+		},
+		{
+			name:    "incomplete negative",
+			input:   "+",
+			wantErr: true,
 		},
 		{
 			name:    "incomplete hex",
@@ -217,6 +241,16 @@ func TestNextString(t *testing.T) {
 			name:  "string followed by other content",
 			input: `"hello" world`,
 			want:  "hello",
+		},
+		{
+			name:  `"true" string`,
+			input: `"true"`,
+			want:  "true",
+		},
+		{
+			name:  `"false" string`,
+			input: `"false"`,
+			want:  "false",
 		},
 	}
 

--- a/v2/codetags/scanner_test.go
+++ b/v2/codetags/scanner_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codetags
+
+import (
+	"testing"
+)
+
+func TestScannerBasics(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []rune
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  []rune{EOF},
+		},
+		{
+			name:  "single character",
+			input: "a",
+			want:  []rune{'a', EOF},
+		},
+		{
+			name:  "multiple characters",
+			input: "abc",
+			want:  []rune{'a', 'b', 'c', EOF},
+		},
+		{
+			name:  "unicode characters",
+			input: "αβγ",
+			want:  []rune{'α', 'β', 'γ', EOF},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := scanner{buf: []rune(tt.input)}
+
+			// next()
+			for _, want := range tt.want {
+				got := s.next()
+				if got != want {
+					t.Errorf("next() = %v, want %v", got, want)
+				}
+			}
+
+			// peek()
+			s = scanner{buf: []rune(tt.input)}
+			for i, want := range tt.want {
+				got := s.peek()
+				if got != want {
+					t.Errorf("peek() at position %d = %v, want %v", i, got, want)
+				}
+				s.next() // Advance scanner
+			}
+
+			// peekN()
+			if len(tt.input) > 1 {
+				s = scanner{buf: []rune(tt.input)}
+				got := s.peekN(1)
+				want := []rune(tt.input)[1]
+				if got != want {
+					t.Errorf("peekN(1) at position 0 = %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNextNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "simple integer",
+			input: "123",
+		},
+		{
+			name:  "negative integer",
+			input: "-123",
+		},
+		{
+			name:  "positive integer with plus sign",
+			input: "+123",
+			want:  "123",
+		},
+		{
+			name:  "zero",
+			input: "0",
+		},
+		{
+			name:  "hex number",
+			input: "0xFF",
+		},
+		{
+			name:  "octal number",
+			input: "0o77",
+		},
+		{
+			name:  "binary number",
+			input: "0b101",
+		},
+		{
+			name:    "incomplete hex",
+			input:   "0x",
+			wantErr: true,
+		},
+		{
+			name:    "incomplete octal",
+			input:   "0o",
+			wantErr: true,
+		},
+		{
+			name:    "incomplete binary",
+			input:   "0b",
+			wantErr: true,
+		},
+		{
+			name:    "number followed by non-digit",
+			input:   "123abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.want == "" {
+				tt.want = tt.input
+			}
+			s := scanner{buf: []rune(tt.input)}
+			got, err := s.nextNumber()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nextNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("nextNumber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "double quoted string",
+			input: `"hello"`,
+			want:  "hello",
+		},
+		{
+			name:  "backtick quoted string",
+			input: "`hello`",
+			want:  "hello",
+		},
+		{
+			name:  "empty double quoted string",
+			input: `""`,
+			want:  "",
+		},
+		{
+			name:  "empty backtick quoted string",
+			input: "``",
+			want:  "",
+		},
+		{
+			name:  "string with escaped quote",
+			input: `"hello \"world\""`,
+			want:  `hello "world"`,
+		},
+		{
+			name:  "string with escaped backslash",
+			input: `"hello \\world"`,
+			want:  `hello \world`,
+		},
+		{
+			name:    "unterminated double quoted string",
+			input:   `"hello`,
+			wantErr: true,
+		},
+		{
+			name:    "unterminated backtick quoted string",
+			input:   "`hello",
+			wantErr: true,
+		},
+		{
+			name:    "invalid escape sequence",
+			input:   `"hello \n world"`,
+			wantErr: true,
+		},
+		{
+			name:  "string followed by other content",
+			input: `"hello" world`,
+			want:  "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := scanner{buf: []rune(tt.input)}
+			got, err := s.nextString()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nextString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("nextString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextIdent(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		isInteriorFn func(rune) bool
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:  "simple identifier with isIdentInterior",
+			input: "abc",
+			want:  "abc",
+		},
+		{
+			name:  "identifier with underscore using isIdentInterior",
+			input: "abc_def",
+			want:  "abc_def",
+		},
+		{
+			name:  "identifier with dash using isIdentInterior",
+			input: "abc-def",
+			want:  "abc-def",
+		},
+		{
+			name:  "identifier with dot using isIdentInterior",
+			input: "abc.def",
+			want:  "abc.def",
+		},
+		{
+			name:  "identifier with numbers using isIdentInterior",
+			input: "abc123",
+			want:  "abc123",
+		},
+		{
+			name:  "identifier with colon using isIdentInterior",
+			input: "abc:def",
+			want:  "abc",
+		},
+		{
+			name:  "identifier followed by invalid character",
+			input: "abc@def",
+			want:  "abc",
+		},
+		{
+			name:  "identifier starting with underscore",
+			input: "_abc",
+			want:  "_abc",
+		},
+		{
+			name:    "identifier starting with number",
+			input:   "123abc",
+			want:    "",
+			wantErr: true,
+		},
+
+		{
+			name:         "identifier with colon using isTagNameInterior",
+			input:        "abc:def",
+			isInteriorFn: isTagNameInterior,
+			want:         "abc:def",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := scanner{buf: []rune(tt.input)}
+			var got string
+			var err error
+
+			if tt.isInteriorFn == nil {
+				tt.isInteriorFn = isIdentInterior
+			}
+			got, err = s.nextIdent(tt.isInteriorFn)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nextIdent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("nextIdent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/codetags/types.go
+++ b/v2/codetags/types.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 )
 
-// TypedTag represents a single comment tag with typed args.
-type TypedTag struct {
+// Tag represents a single comment tag with typed args.
+type Tag struct {
 	// Name is the name of the tag with no arguments.
 	Name string
 
@@ -35,7 +35,7 @@ type TypedTag struct {
 
 	// ValueTag is another tag parsed from the value of this tag.
 	// Provides the tag value when ValueType is ValueTypeTag.
-	ValueTag *TypedTag
+	ValueTag *Tag
 
 	// ValueType is the type of the value.
 	ValueType ValueType
@@ -43,7 +43,7 @@ type TypedTag struct {
 
 // String returns the canonical string representation of the tag.
 // All strings are represented in double quotes. Spacing is normalized.
-func (t TypedTag) String() string {
+func (t Tag) String() string {
 	buf := strings.Builder{}
 	buf.WriteString(t.Name)
 	if len(t.Args) > 0 {

--- a/v2/codetags/types.go
+++ b/v2/codetags/types.go
@@ -41,6 +41,8 @@ type TypedTag struct {
 	ValueType ValueType
 }
 
+// String returns the canonical string representation of the tag.
+// All strings are represented in double quotes. Spacing is normalized.
 func (t TypedTag) String() string {
 	buf := strings.Builder{}
 	buf.WriteString(t.Name)

--- a/v2/codetags/types.go
+++ b/v2/codetags/types.go
@@ -41,6 +41,29 @@ type Tag struct {
 	ValueType ValueType
 }
 
+// PositionalArg returns the positional argument. If there is no positional
+// argument, it returns false.
+func (t Tag) PositionalArg() (Arg, bool) {
+	if len(t.Args) == 0 || len(t.Args[0].Name) > 0 {
+		return Arg{}, false
+	}
+	return t.Args[0], true
+}
+
+// NamedArg returns the named argument. If o named argument is found, it returns
+// false. Always returns false for empty name; use PositionalArg instead.
+func (t Tag) NamedArg(name string) (Arg, bool) {
+	if len(name) == 0 {
+		return Arg{}, false
+	}
+	for _, arg := range t.Args {
+		if arg.Name == name {
+			return arg, true
+		}
+	}
+	return Arg{}, false
+}
+
 // String returns the canonical string representation of the tag.
 // All strings are represented in double quotes. Spacing is normalized.
 func (t Tag) String() string {

--- a/v2/codetags/types.go
+++ b/v2/codetags/types.go
@@ -137,7 +137,8 @@ const (
 	// ValueTypeTag identifies that the value is another tag.
 	ValueTypeTag ValueType = "tag"
 
-	// ValueTypeRaw identifies that the value is the unparsed text following the "=" sign.
-	// Only set when ParseOptions.RawValues is true.
+	// ValueTypeRaw identifies that the value is raw, untyped content and contains
+	// all text from the tag declaration following the "=" sign, up to the last
+	// non-whitespace character.
 	ValueTypeRaw ValueType = "raw"
 )

--- a/v2/codetags/types.go
+++ b/v2/codetags/types.go
@@ -25,22 +25,19 @@ import (
 type TypedTag struct {
 	// Name is the name of the tag with no arguments.
 	Name string
+
 	// Args is a list of optional arguments to the tag.
 	Args []Arg
+
 	// Value is the string representation of the tag value.
-	// Only used when ValueType is ValueTypeString, ValueTypeBool, ValueTypeInt or ValueTypeRaw.
+	// Provides the tag value when ValueType is ValueTypeString, ValueTypeBool, ValueTypeInt or ValueTypeRaw.
 	Value string
 
 	// ValueTag is another tag parsed from the value of this tag.
-	// Only used when ValueType is ValueTypeTag.
+	// Provides the tag value when ValueType is ValueTypeTag.
 	ValueTag *TypedTag
 
 	// ValueType is the type of the value.
-	// If ValueType is ValueTypeTag, ValueTag is set.
-	// If ValueType is ValueTypeString, ValueTypeBool or ValueTypeInt, Value is the string representation
-	// of the typed value.
-	// If ValueType is ValueTypeRaw, Value is the exact text following the "=" sign.
-	// If ValueType is empty, the tag has no value.
 	ValueType ValueType
 }
 
@@ -57,7 +54,7 @@ func (t TypedTag) String() string {
 		}
 		buf.WriteString(")")
 	}
-	if len(t.ValueType) > 0 || len(t.Value) > 0 {
+	if t.ValueType != ValueTypeNone {
 		if t.ValueType == ValueTypeTag {
 			buf.WriteString("=+")
 			buf.WriteString(t.ValueTag.String())
@@ -77,6 +74,7 @@ func (t TypedTag) String() string {
 type Arg struct {
 	// Name is the name of a named argument. This is zero-valued for positional arguments.
 	Name string
+
 	// Value is the string value of an argument. It has been validated to match the Type.
 	// See the ArgType const godoc for further details on how to parse the value for the
 	// Type.
@@ -86,14 +84,13 @@ type Arg struct {
 	Type ArgType
 }
 
-// String returns the string representation of the argument.
 func (a Arg) String() string {
 	buf := strings.Builder{}
 	if len(a.Name) > 0 {
 		buf.WriteString(a.Name)
 		buf.WriteString(": ")
 	}
-	if a.Type == ArgTypeString { // identifiers are unquoted
+	if a.Type == ArgTypeString {
 		buf.WriteString(strconv.Quote(a.Value))
 	} else {
 		buf.WriteString(a.Value)
@@ -122,6 +119,9 @@ const (
 type ValueType string
 
 const (
+	// ValueTypeNone indicates that the tag has no value.
+	ValueTypeNone ValueType = ""
+
 	// ValueTypeString identifies string values.
 	ValueTypeString ValueType = "string"
 

--- a/v2/codetags/types_test.go
+++ b/v2/codetags/types_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codetags
+
+import (
+	"testing"
+)
+
+func TestTypedTagString(t *testing.T) {
+	tests := []struct {
+		name     string
+		tag      TypedTag
+		expected string
+	}{
+		{
+			name: "simple tag name",
+			tag: TypedTag{
+				Name: "name",
+			},
+			expected: "name",
+		},
+		{
+			name: "tag with single string arg",
+			tag: TypedTag{
+				Name: "tag",
+				Args: []Arg{
+					{Value: "value", Type: ArgTypeString},
+				},
+			},
+			expected: `tag("value")`,
+		},
+		{
+			name: "tag with multiple positional args",
+			tag: TypedTag{
+				Name: "tag",
+				Args: []Arg{
+					{Value: "value1", Type: ArgTypeString},
+					{Value: "value2", Type: ArgTypeString},
+				},
+			},
+			expected: `tag("value1", "value2")`,
+		},
+		{
+			name: "tag with quoted string arg",
+			tag: TypedTag{
+				Name: "tag",
+				Args: []Arg{
+					{Value: "value with spaces", Type: ArgTypeString},
+				},
+			},
+			expected: `tag("value with spaces")`,
+		},
+		{
+			name: "tag with named args",
+			tag: TypedTag{
+				Name: "tag",
+				Args: []Arg{
+					{Name: "arg1", Value: "value1", Type: ArgTypeString},
+					{Name: "arg2", Value: "value2", Type: ArgTypeString},
+				},
+			},
+			expected: `tag(arg1: "value1", arg2: "value2")`,
+		},
+		{
+			name: "tag with named arg of different types",
+			tag: TypedTag{
+				Name: "tag",
+				Args: []Arg{
+					{Name: "str", Value: "string value", Type: ArgTypeString},
+					{Name: "int", Value: "42", Type: ArgTypeInt},
+					{Name: "bool", Value: "true", Type: ArgTypeBool},
+				},
+			},
+			expected: `tag(str: "string value", int: 42, bool: true)`,
+		},
+		{
+			name: "tag with string value",
+			tag: TypedTag{
+				Name:      "tag",
+				Value:     "value",
+				ValueType: ValueTypeString,
+			},
+			expected: `tag="value"`,
+		},
+		{
+			name: "tag with integer value",
+			tag: TypedTag{
+				Name:      "tag",
+				Value:     "42",
+				ValueType: ValueTypeInt,
+			},
+			expected: "tag=42",
+		},
+		{
+			name: "tag with boolean value",
+			tag: TypedTag{
+				Name:      "tag",
+				Value:     "true",
+				ValueType: ValueTypeBool,
+			},
+			expected: "tag=true",
+		},
+		{
+			name: "tag with raw value",
+			tag: TypedTag{
+				Name:      "tag",
+				Value:     "some raw value // with comment",
+				ValueType: ValueTypeRaw,
+			},
+			expected: "tag=some raw value // with comment",
+		},
+		{
+			name: "tag with nested tag value",
+			tag: TypedTag{
+				Name:      "outer",
+				ValueType: ValueTypeTag,
+				ValueTag: &TypedTag{
+					Name: "inner",
+				},
+			},
+			expected: "outer=+inner",
+		},
+		{
+			name: "complex nested tags",
+			tag: TypedTag{
+				Name: "level1",
+				Args: []Arg{
+					{Name: "arg", Value: "value", Type: ArgTypeString},
+				},
+				ValueType: ValueTypeTag,
+				ValueTag: &TypedTag{
+					Name: "level2",
+					Args: []Arg{
+						{Value: "42", Type: ArgTypeInt},
+					},
+					ValueType: ValueTypeTag,
+					ValueTag: &TypedTag{
+						Name:      "level3",
+						Value:     "final",
+						ValueType: ValueTypeString,
+					},
+				},
+			},
+			expected: `level1(arg: "value")=+level2(42)=+level3="final"`,
+		},
+		{
+			name: "tag with args and string value",
+			tag: TypedTag{
+				Name: "tag",
+				Args: []Arg{
+					{Value: "arg", Type: ArgTypeString},
+				},
+				Value:     "value",
+				ValueType: ValueTypeString,
+			},
+			expected: `tag("arg")="value"`,
+		},
+		{
+			name: "tag with args and nested tag value",
+			tag: TypedTag{
+				Name: "outer",
+				Args: []Arg{
+					{Name: "param", Value: "value", Type: ArgTypeString},
+				},
+				ValueType: ValueTypeTag,
+				ValueTag: &TypedTag{
+					Name: "inner",
+					Args: []Arg{
+						{Value: "innerArg", Type: ArgTypeString},
+					},
+				},
+			},
+			expected: `outer(param: "value")=+inner("innerArg")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.tag.String()
+			if result != tt.expected {
+				t.Errorf("got: %q, want: %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/v2/codetags/types_test.go
+++ b/v2/codetags/types_test.go
@@ -23,19 +23,19 @@ import (
 func TestTypedTagString(t *testing.T) {
 	tests := []struct {
 		name     string
-		tag      TypedTag
+		tag      Tag
 		expected string
 	}{
 		{
 			name: "simple tag name",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "name",
 			},
 			expected: "name",
 		},
 		{
 			name: "tag with single string arg",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "tag",
 				Args: []Arg{
 					{Value: "value", Type: ArgTypeString},
@@ -45,7 +45,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with multiple positional args",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "tag",
 				Args: []Arg{
 					{Value: "value1", Type: ArgTypeString},
@@ -56,7 +56,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with quoted string arg",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "tag",
 				Args: []Arg{
 					{Value: "value with spaces", Type: ArgTypeString},
@@ -66,7 +66,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with named args",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "tag",
 				Args: []Arg{
 					{Name: "arg1", Value: "value1", Type: ArgTypeString},
@@ -77,7 +77,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with named arg of different types",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "tag",
 				Args: []Arg{
 					{Name: "str", Value: "string value", Type: ArgTypeString},
@@ -89,7 +89,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with string value",
-			tag: TypedTag{
+			tag: Tag{
 				Name:      "tag",
 				Value:     "value",
 				ValueType: ValueTypeString,
@@ -98,7 +98,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with integer value",
-			tag: TypedTag{
+			tag: Tag{
 				Name:      "tag",
 				Value:     "42",
 				ValueType: ValueTypeInt,
@@ -107,7 +107,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with boolean value",
-			tag: TypedTag{
+			tag: Tag{
 				Name:      "tag",
 				Value:     "true",
 				ValueType: ValueTypeBool,
@@ -116,7 +116,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with raw value",
-			tag: TypedTag{
+			tag: Tag{
 				Name:      "tag",
 				Value:     "some raw value // with comment",
 				ValueType: ValueTypeRaw,
@@ -125,10 +125,10 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with nested tag value",
-			tag: TypedTag{
+			tag: Tag{
 				Name:      "outer",
 				ValueType: ValueTypeTag,
-				ValueTag: &TypedTag{
+				ValueTag: &Tag{
 					Name: "inner",
 				},
 			},
@@ -136,19 +136,19 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "complex nested tags",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "level1",
 				Args: []Arg{
 					{Name: "arg", Value: "value", Type: ArgTypeString},
 				},
 				ValueType: ValueTypeTag,
-				ValueTag: &TypedTag{
+				ValueTag: &Tag{
 					Name: "level2",
 					Args: []Arg{
 						{Value: "42", Type: ArgTypeInt},
 					},
 					ValueType: ValueTypeTag,
-					ValueTag: &TypedTag{
+					ValueTag: &Tag{
 						Name:      "level3",
 						Value:     "final",
 						ValueType: ValueTypeString,
@@ -159,7 +159,7 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with args and string value",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "tag",
 				Args: []Arg{
 					{Value: "arg", Type: ArgTypeString},
@@ -171,13 +171,13 @@ func TestTypedTagString(t *testing.T) {
 		},
 		{
 			name: "tag with args and nested tag value",
-			tag: TypedTag{
+			tag: Tag{
 				Name: "outer",
 				Args: []Arg{
 					{Name: "param", Value: "value", Type: ArgTypeString},
 				},
 				ValueType: ValueTypeTag,
-				ValueTag: &TypedTag{
+				ValueTag: &Tag{
 					Name: "inner",
 					Args: []Arg{
 						{Value: "innerArg", Type: ArgTypeString},

--- a/v2/comments.go
+++ b/v2/comments.go
@@ -107,7 +107,7 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 			continue
 		}
 		for _, line := range tagLines {
-			typedTag, err := codetags.Parse(line)
+			typedTag, err := codetags.Parse(line, codetags.ParseOptions{RawValues: true})
 			if err != nil {
 				return nil, err
 			}

--- a/v2/comments.go
+++ b/v2/comments.go
@@ -76,8 +76,8 @@ func ExtractCommentTags(marker string, lines []string) map[string][]string {
 //
 // This function is a wrapper around codetags.Extract and codetags.Parse, but only supports tags with
 // a single position arg of type string, and a value of type bool.
-func ExtractSingleBoolCommentTag(marker string, key string, defaultVal bool, lines []string) (bool, error) {
-	tags, err := ExtractFunctionStyleCommentTags(marker, []string{key}, lines)
+func ExtractSingleBoolCommentTag(marker string, key string, defaultVal bool, lines []string, options ...TagOpt) (bool, error) {
+	tags, err := ExtractFunctionStyleCommentTags(marker, []string{key}, lines, options...)
 	if err != nil {
 		return false, err
 	}
@@ -98,7 +98,12 @@ func ExtractSingleBoolCommentTag(marker string, key string, defaultVal bool, lin
 //
 // This function is a wrapper around codetags.Extract and codetags.Parse, but only supports tags with
 // a single position arg of type string.
-func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []string) (map[string][]Tag, error) {
+func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []string, options ...TagOpt) (map[string][]Tag, error) {
+	opts := tagOpts{}
+	for _, o := range options {
+		o(opts)
+	}
+
 	out := map[string][]Tag{}
 
 	tags := codetags.Extract(marker, lines)
@@ -107,7 +112,7 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 			continue
 		}
 		for _, line := range tagLines {
-			typedTag, err := codetags.Parse(line, codetags.ParseOptions{RawValues: true})
+			typedTag, err := codetags.Parse(line, codetags.ParseOptions{RawValues: !opts.parseValues})
 			if err != nil {
 				return nil, err
 			}
@@ -120,6 +125,23 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 	}
 
 	return out, nil
+}
+
+// TagOpt provides options for extracting tags.
+type TagOpt func(opts tagOpts)
+
+// TagOptParseValues enables parsing of tag values. When enabled, tag values must
+// be valid quoted strings, ints, booleans, identifiers, or tags. Otherwise, a
+// parse error will be returned. Also, when enabled, trailing comments are
+// ignored.
+func TagOptParseValues() func(opts tagOpts) {
+	return func(opts tagOpts) {
+		opts.parseValues = true
+	}
+}
+
+type tagOpts struct {
+	parseValues bool
 }
 
 func toTag(tag codetags.TypedTag) (Tag, error) {

--- a/v2/comments.go
+++ b/v2/comments.go
@@ -116,7 +116,7 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 			if err != nil {
 				return nil, err
 			}
-			tag, err := toTag(typedTag)
+			tag, err := toStringArgs(typedTag)
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +145,7 @@ type tagOpts struct {
 	parseValues bool
 }
 
-func toTag(tag codetags.TypedTag) (Tag, error) {
+func toStringArgs(tag codetags.Tag) (Tag, error) {
 	var stringArgs []string
 	if len(tag.Args) > 1 {
 		return Tag{}, fmt.Errorf("expected one argument, got: %v", tag.Args)

--- a/v2/comments.go
+++ b/v2/comments.go
@@ -76,8 +76,8 @@ func ExtractCommentTags(marker string, lines []string) map[string][]string {
 //
 // This function is a wrapper around codetags.Extract and codetags.Parse, but only supports tags with
 // a single position arg of type string, and a value of type bool.
-func ExtractSingleBoolCommentTag(marker string, key string, defaultVal bool, lines []string, options ...TagOpt) (bool, error) {
-	tags, err := ExtractFunctionStyleCommentTags(marker, []string{key}, lines, options...)
+func ExtractSingleBoolCommentTag(marker string, key string, defaultVal bool, lines []string) (bool, error) {
+	tags, err := ExtractFunctionStyleCommentTags(marker, []string{key}, lines, ParseValues(true))
 	if err != nil {
 		return false, err
 	}
@@ -98,10 +98,10 @@ func ExtractSingleBoolCommentTag(marker string, key string, defaultVal bool, lin
 //
 // This function is a wrapper around codetags.Extract and codetags.Parse, but only supports tags with
 // a single position arg of type string.
-func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []string, options ...TagOpt) (map[string][]Tag, error) {
+func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []string, options ...TagOption) (map[string][]Tag, error) {
 	opts := tagOpts{}
 	for _, o := range options {
-		o(opts)
+		o(&opts)
 	}
 
 	out := map[string][]Tag{}
@@ -112,7 +112,7 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 			continue
 		}
 		for _, line := range tagLines {
-			typedTag, err := codetags.Parse(line, codetags.ParseOptions{RawValues: !opts.parseValues})
+			typedTag, err := codetags.Parse(line, codetags.RawValues(!opts.parseValues))
 			if err != nil {
 				return nil, err
 			}
@@ -127,16 +127,17 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 	return out, nil
 }
 
-// TagOpt provides options for extracting tags.
-type TagOpt func(opts tagOpts)
+// TagOption provides an option for extracting tags.
+type TagOption func(opts *tagOpts)
 
-// TagOptParseValues enables parsing of tag values. When enabled, tag values must
+// ParseValues enables parsing of tag values. When enabled, tag values must
 // be valid quoted strings, ints, booleans, identifiers, or tags. Otherwise, a
 // parse error will be returned. Also, when enabled, trailing comments are
 // ignored.
-func TagOptParseValues() func(opts tagOpts) {
-	return func(opts tagOpts) {
-		opts.parseValues = true
+// Default: disabled
+func ParseValues(enabled bool) TagOption {
+	return func(opts *tagOpts) {
+		opts.parseValues = enabled
 	}
 }
 

--- a/v2/comments_test.go
+++ b/v2/comments_test.go
@@ -50,7 +50,7 @@ func TestExtractSingleBoolCommentTag(t *testing.T) {
 	commentLines := []string{
 		"Human comment that is ignored.",
 		"+TRUE=true",
-		"+FALSE=false // comment",
+		"+FALSE=false # comment",
 		"+MULTI=true",
 		"+MULTI=false",
 		"+MULTI=multi",
@@ -267,9 +267,9 @@ func TestExtractFunctionStyleCommentTags(t *testing.T) {
 	}, {
 		name: "ParseValues - comments ignored",
 		comments: []string{
-			"+boolTag=true // this is a boolean",
-			"+intTag=42 // this is an integer",
-			"+stringTag=\"quoted string\" // this is a string",
+			"+boolTag=true # this is a boolean",
+			"+intTag=42 # this is an integer",
+			"+stringTag=\"quoted string\" # this is a string",
 		},
 		parseValues: true,
 		expect: map[string][]Tag{


### PR DESCRIPTION
Builds on https://github.com/kubernetes/gengo/pull/299

Extends the grammar to parse values, support chained tags and ignore all trailing comments. This is opt-in for existing functions (for backward compat) and opt-out for the direct calls to the new parser API (to encourage new use cases to parse values).

For example,

```
// Chain tags with a dedicated operator:

name(limit: 10, path: "/xyz")=+anotherTag(size: 100)

// Values must be string, bool, int or identifier:

name=identifier
name="double-quoted value"
name=`backtick-quoted value`
"name(100)
name(true)
```

Change to grammar:

```
<tag>             ::= <tagName> [ "(" [ <args> ] ")" ] [ "=" <value> | "=+" <tag> ]
<value>           ::= <identifier> | <string> | <int> | <bool>
```
