### PR TITLE
Fix integer types to use go int primitives

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -456,6 +456,10 @@ var (
 		Name: Name{Name: "int16"},
 		Kind: Builtin,
 	}
+	Int8 = &Type{
+		Name: Name{Name: "int8"},
+		Kind: Builtin,
+	}
 	Int = &Type{
 		Name: Name{Name: "int"},
 		Kind: Builtin,
@@ -470,6 +474,10 @@ var (
 	}
 	Uint16 = &Type{
 		Name: Name{Name: "uint16"},
+		Kind: Builtin,
+	}
+	Uint8 = &Type{
+		Name: Name{Name: "uint8"},
 		Kind: Builtin,
 	}
 	Uint = &Type{
@@ -509,12 +517,12 @@ var (
 			"int64":   Int64,
 			"int32":   Int32,
 			"int16":   Int16,
-			"int8":    Byte,
+			"int8":    Int8,
 			"uint":    Uint,
 			"uint64":  Uint64,
 			"uint32":  Uint32,
 			"uint16":  Uint16,
-			"uint8":   Byte,
+			"uint8":   Uint8,
 			"uintptr": Uintptr,
 			"byte":    Byte,
 			"float":   Float,
@@ -529,7 +537,7 @@ var (
 
 func IsInteger(t *Type) bool {
 	switch t {
-	case Int, Int64, Int32, Int16, Uint, Uint64, Uint32, Uint16, Byte:
+	case Int, Int64, Int32, Int16, Int8, Uint, Uint64, Uint32, Uint16, Uint8, Byte:
 		return true
 	default:
 		return false

--- a/v2/types/types.go
+++ b/v2/types/types.go
@@ -483,6 +483,10 @@ var (
 		Name: Name{Name: "int16"},
 		Kind: Builtin,
 	}
+	Int8 = &Type{
+		Name: Name{Name: "int8"},
+		Kind: Builtin,
+	}
 	Int = &Type{
 		Name: Name{Name: "int"},
 		Kind: Builtin,
@@ -497,6 +501,10 @@ var (
 	}
 	Uint16 = &Type{
 		Name: Name{Name: "uint16"},
+		Kind: Builtin,
+	}
+	Uint8 = &Type{
+		Name: Name{Name: "uint8"},
 		Kind: Builtin,
 	}
 	Uint = &Type{
@@ -537,12 +545,12 @@ var (
 			"int64":   Int64,
 			"int32":   Int32,
 			"int16":   Int16,
-			"int8":    Byte,
+			"int8":    Int8,
 			"uint":    Uint,
 			"uint64":  Uint64,
 			"uint32":  Uint32,
 			"uint16":  Uint16,
-			"uint8":   Byte,
+			"uint8":   Uint8,
 			"uintptr": Uintptr,
 			"byte":    Byte,
 			"float":   Float,
@@ -567,7 +575,7 @@ func PointerTo(t *Type) *Type {
 
 func IsInteger(t *Type) bool {
 	switch t {
-	case Int, Int64, Int32, Int16, Uint, Uint64, Uint32, Uint16, Byte:
+	case Int, Int64, Int32, Int16, Int8, Uint, Uint64, Uint32, Uint16, Uint8, Byte:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Modified the mapped value types for integers to use the corresponding go int primitives instead of Byte. Fixes: https://github.com/kubernetes/gengo/issues/171