### PR TITLE
Add an option to forbid tag arguments

### DIFF
--- a/v2/comments.go
+++ b/v2/comments.go
@@ -116,7 +116,7 @@ func ExtractFunctionStyleCommentTags(marker string, tagNames []string, lines []s
 			if err != nil {
 				return nil, err
 			}
-			tag, err := toStringArgs(typedTag)
+			tag, err := toStringArgs(typedTag, opts.forbidArguments)
 			if err != nil {
 				return nil, err
 			}
@@ -141,13 +141,26 @@ func ParseValues(enabled bool) TagOption {
 	}
 }
 
-type tagOpts struct {
-	parseValues bool
+// ForbidArguments bans tag arguments. When enabled, tag arguments
+// must be empty. Otherwise, a parse error will be returned.
+// Default: disabled
+func ForbidArguments(enabled bool) TagOption {
+	return func(opts *tagOpts) {
+		opts.forbidArguments = enabled
+	}
 }
 
-func toStringArgs(tag codetags.Tag) (Tag, error) {
+type tagOpts struct {
+	parseValues     bool
+	forbidArguments bool
+}
+
+func toStringArgs(tag codetags.Tag, forbidArguments bool) (Tag, error) {
 	var stringArgs []string
-	if len(tag.Args) > 1 {
+	if forbidArguments && len(tag.Args) > 0 {
+		return Tag{}, fmt.Errorf("expected no arguments, got: %v", tag.Args)
+	}
+	if !forbidArguments && len(tag.Args) > 1 {
 		return Tag{}, fmt.Errorf("expected one argument, got: %v", tag.Args)
 	}
 	for _, arg := range tag.Args {


### PR DESCRIPTION
Part of kubernetes/kubernetes#130358

`ExtractCommentTags` is deprecated. Old tags are not in function style so the migration to `ExtractFunctionStyleCommentTags` is not straightforward. This new option offers an easier migration path to parse non-function style tags.

We have agreed that we want to be strict and have the code generator fail with an error if an unexpected argument is present. Refer to the discussion [here](https://github.com/kubernetes/kubernetes/pull/131711/files#r2132934997).

This can unblock the migration of `ExtractCommentTags` usages in kube-openapi, and eliminate an utility function introduced in kubernetes/kubernetes#131711.

cc @jpbetz @yongruilin