### PR TITLE
Call goimports AND gofmt -s

### DIFF
--- a/v2/generator/execute.go
+++ b/v2/generator/execute.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -114,19 +115,44 @@ func assembleGoFile(w io.Writer, f *File) {
 	w.Write(f.Body.Bytes())
 }
 
+func formatCode(src []byte) ([]byte, error) {
+	// We call goimports because it formats imports better than gofmt, but also
+	// call gofmt because it has the "simplify" logic.
+	src, err := importsWrapper(src)
+	if err != nil {
+		return nil, err
+	}
+	return gofmtWrapper(src)
+}
+
 func importsWrapper(src []byte) ([]byte, error) {
 	opt := imports.Options{
 		Comments:   true,
 		TabIndent:  true,
 		TabWidth:   8,
-		FormatOnly: true, // Disable the insertion and deletion of imports
+		FormatOnly: true, // Disable the insertion and deletion of imports (slow!)
 	}
 	return imports.Process("", src, &opt)
 }
 
+func gofmtWrapper(src []byte) ([]byte, error) {
+	cmd := exec.Command("gofmt", "-s")
+	cmd.Stdin = bytes.NewReader(src)
+	stdout := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return nil, fmt.Errorf("gofmt failed: %v: %s", err, strings.TrimSpace(stderr.String()))
+		}
+	}
+	return stdout.Bytes(), nil
+}
+
 func NewGoFile() *DefaultFileType {
 	return &DefaultFileType{
-		Format:   importsWrapper,
+		Format:   formatCode,
 		Assemble: assembleGoFile,
 	}
 }


### PR DESCRIPTION
goimports does not have the `-s` flag but gofmt does not handle imports properly.