### PR TITLE
Fix gofmt missing case in code generator

### DIFF
--- a/v2/generator/execute.go
+++ b/v2/generator/execute.go
@@ -141,7 +141,7 @@ func gofmtWrapper(src []byte) ([]byte, error) {
 
 	if _, err := exec.LookPath(gofmt); err != nil {
 		klog.Errorf("WARNING: skipping output simplification: %v", err)
-		return nil, nil
+		return src, nil
 	}
 
 	cmd := exec.Command(gofmt, "-s")


### PR DESCRIPTION
Fix gofmt missing case in code generator. Fixes https://github.com/kubernetes/kubernetes/issues/134207

/assign @thockin @BenTheElder 